### PR TITLE
Write no_stories metadata.json when Gemini returns zero stories

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -579,6 +579,15 @@ def process_video(
         (meeting_dir / "metadata.json").write_text(json.dumps(metadata))
         return "content_written"
 
+    # Gemini returned an empty story list — write metadata so this video is
+    # not re-submitted to the AI on future runs.
+    metadata = {
+        "video_id": video_id,
+        "video_title": video_title,
+        "status": "no_stories",
+        "processed_at": time.time(),
+    }
+    (meeting_dir / "metadata.json").write_text(json.dumps(metadata))
     return "skipped"
 
 


### PR DESCRIPTION
Prevents future runs from re-submitting the same video to the AI when the model found nothing relevant to report.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk