### PR TITLE
Rebuild meta feed after each channel instead of once at the end

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -796,9 +796,10 @@ def main() -> None:
             ai_disabled = True
         if content_changed:
             rebuild_feed(STORAGE_ROOT / slugify(feed["channel_name"]), feed)
+            rebuild_meta_feed(base_url=config.get("base_url", ""))
             any_content_changed = True
 
-    if any_content_changed or not (STORAGE_ROOT / "rss.xml").exists():
+    if not any_content_changed and not (STORAGE_ROOT / "rss.xml").exists():
         rebuild_meta_feed(base_url=config.get("base_url", ""))
 
     logger.info("Session End.")


### PR DESCRIPTION
Makes results visible in the RSS feed as each channel finishes processing rather than waiting for the entire run to complete.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk