### PR TITLE
Move RSS link to nav bar as icon; all blog links now relative

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -788,12 +788,8 @@ def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_
         f"{len(all_stories)} stories from {len(subscribed)} channel{'s' if len(subscribed) != 1 else ''} "
         f"— last {blog_days} days"
     )
-    nav_root = base_url.rstrip("/") if base_url else ""
-    if base_url:
-        rss_href = f"{base_url}/users/{slugify(name)}/rss.xml"
-        rss_link = f'<link rel="alternate" type="application/rss+xml" title="{page_title}" href="{rss_href}">'
-    else:
-        rss_link = ""
+    rss_feed_path = f"/feed/{user['feed_token']}.xml"
+    rss_link = f'<link rel="alternate" type="application/rss+xml" title="{page_title}" href="{rss_feed_path}">'
 
     html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -813,6 +809,7 @@ def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_
         nav.blog-nav a {{ color: #2563eb; text-decoration: none; font-size: 0.9rem; }}
         nav.blog-nav a:hover {{ text-decoration: underline; }}
         nav.blog-nav .nav-brand {{ font-weight: 700; font-size: 1.1rem; }}
+        nav.blog-nav .nav-rss {{ display: flex; align-items: center; }}
         {CSS}
 </style>
 </head>
@@ -822,6 +819,13 @@ def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_
     <a href="/" class="nav-brand">TubeNews</a>
     <a href="/dashboard">My feed</a>
   </div>
+  <a href="{rss_feed_path}" class="nav-rss" title="Subscribe via RSS">
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="3" cy="13" r="2" fill="#f26522"/>
+      <path fill="#f26522" d="M1 5a8 8 0 0 1 8 8H7a6 6 0 0 0-6-6V5z"/>
+      <path fill="#f26522" d="M1 1a12 12 0 0 1 12 12h-2A10 10 0 0 0 1 3V1z"/>
+    </svg>
+  </a>
 </nav>
 <div class="blog-content">
 <h1>{page_title}</h1>

--- a/web/app.py
+++ b/web/app.py
@@ -508,7 +508,7 @@ def serve_blog_public(token: str):
                 stories = _get_user_stories(data, cfg.get("blog_days", 90))
                 blog_name = data.get("blog_name") or f"{data['name']}'s TubeNews"
                 return render_template("blog.html", stories=stories, blog_name=blog_name,
-                                       feed_url=_feed_url(token))
+                                       feed_path=f"/feed/{token}.xml")
         except Exception:
             continue
     abort(404)
@@ -525,7 +525,7 @@ def serve_blog():
     stories = _get_user_stories(current_user._data, cfg.get("blog_days", 90))
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
     return render_template("blog.html", stories=stories, blog_name=blog_name,
-                           feed_url=_feed_url(current_user.feed_token))
+                           feed_path=f"/feed/{current_user.feed_token}.xml")
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -66,6 +66,9 @@ nav a:hover { text-decoration: underline; }
 }
 .nav-user:hover { color: var(--text); text-decoration: underline; }
 
+.nav-rss { display: flex; align-items: center; line-height: 0; }
+.nav-rss:hover { opacity: 0.75; }
+
 /* Main */
 main {
   max-width: var(--max-w);

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -26,6 +26,7 @@
         <a href="{{ url_for('login') }}">Log in</a>
         <a href="{{ url_for('register') }}">Create account</a>
       {% endif %}
+      {% block nav_extra %}{% endblock %}
     </nav>
   </header>
 

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -1,11 +1,22 @@
 {% extends "base.html" %}
 {% block title %}{{ blog_name }}{% endblock %}
 
+{% block nav_extra %}
+  {% if feed_path %}
+    <a href="{{ feed_path }}" class="nav-rss" title="Subscribe via RSS">
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">
+        <circle cx="3" cy="13" r="2" fill="#f26522"/>
+        <path fill="#f26522" d="M1 5a8 8 0 0 1 8 8H7a6 6 0 0 0-6-6V5z"/>
+        <path fill="#f26522" d="M1 1a12 12 0 0 1 12 12h-2A10 10 0 0 0 1 3V1z"/>
+      </svg>
+    </a>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 <div class="blog-page">
   <div class="blog-header">
     <h1>{{ blog_name }}</h1>
-    <p class="blog-meta"><a href="{{ feed_url }}">RSS feed</a></p>
   </div>
 
   {% if stories %}


### PR DESCRIPTION
- Remove RSS text link from blog-header; add orange RSS SVG icon to header nav via nav_extra block (base.html + blog.html)
- Pass relative feed_path (/feed/<token>.xml) to blog template instead of absolute feed_url — eliminates http/https mismatch
- rebuild_user_blog: use relative /feed/<token>.xml everywhere; always emit <link rel="alternate"> (no longer gated on base_url); add RSS icon to standalone nav

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk