### PR TITLE
Add transcript viewer and fix AI prompt example city

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -393,7 +393,7 @@ def call_gemini_api(
         "Pyramid style.\n"
         "2. CONTENT: Focus on the 'Why it Matters'. Skip ceremonial talk.\n"
         "3. DATELINE: Construct a formal AP-style dateline "
-        "(e.g., 'GONZALES, Calif. — March 14, 2026').\n\n"
+        "(e.g., 'SPRINGFIELD, Mo. — March 14, 2026').\n\n"
         "Return result ONLY as raw JSON list of objects with keys: "
         "'title', 'dateline', 'content', 'start_time_seconds'."
     )
@@ -733,7 +733,8 @@ def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_
                 if metadata.get("processed_at", 0) < cutoff:
                     continue
                 for story_file in meeting_dir.glob("[0-9]*.md"):
-                    all_stories.append({"file": story_file, "meta": metadata, "channel_name": channel_name})
+                    all_stories.append({"file": story_file, "meta": metadata, "channel_name": channel_name,
+                                        "channel_slug": channel_dir.name, "meeting_id": meeting_dir.name})
             except Exception:
                 continue
 
@@ -771,13 +772,19 @@ def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_
             for p in story["body_html"].split("<br>")
             if p.strip()
         )
+        transcript_link = ""
+        if entry.get("channel_slug") and entry.get("meeting_id"):
+            t_url = f"/transcript/{entry['channel_slug']}/{entry['meeting_id']}#t{story['start_seconds']}"
+            transcript_link = f" &mdash; <a class='watch' href='{t_url}' target='_blank' rel='noopener'>&#128221; Read transcript</a>"
         story_blocks.append(
             f"<article>\n"
             f"  <h2>{story['title']}</h2>\n"
             f"  <p class='dateline'>{story['dateline']}</p>\n"
             f"  <p class='source'>{entry['channel_name']}"
             + (f" &mdash; <em>{video_title}</em>" if video_title else "")
-            + f" &mdash; <a class='watch' href='{yt_url}' target='_blank' rel='noopener'>&#9654; Watch source</a></p>\n"
+            + f" &mdash; <a class='watch' href='{yt_url}' target='_blank' rel='noopener'>&#9654; Watch source</a>"
+            + transcript_link
+            + f"</p>\n"
             f"  <div class='body'>{paras}</div>\n"
             f"</article>"
         )

--- a/web/app.py
+++ b/web/app.py
@@ -328,7 +328,8 @@ def _get_user_stories(user_data: dict, blog_days: int = 90) -> list[dict]:
                 if meta.get("processed_at", 0) < cutoff:
                     continue
                 for story_file in meeting_dir.glob("[0-9]*.md"):
-                    raw.append({"file": story_file, "meta": meta, "channel_name": channel_name})
+                    raw.append({"file": story_file, "meta": meta, "channel_name": channel_name,
+                                "channel_slug": channel_dir.name, "meeting_id": meeting_dir.name})
             except Exception:
                 continue
     raw.sort(key=lambda e: e["meta"].get("processed_at", 0), reverse=True)
@@ -344,6 +345,8 @@ def _get_user_stories(user_data: dict, blog_days: int = 90) -> list[dict]:
                 "video_id": entry["meta"]["video_id"],
                 "video_title": entry["meta"].get("video_title", ""),
                 "channel_name": entry["channel_name"],
+                "channel_slug": entry.get("channel_slug", ""),
+                "meeting_id": entry.get("meeting_id", ""),
                 "processed_at": entry["meta"].get("processed_at", 0),
             })
         except Exception:
@@ -371,6 +374,37 @@ def serve_archive(filename=""):
         abort(404)
     mimetype = "application/rss+xml" if filename.endswith(".xml") else None
     return send_from_directory(STORAGE_ROOT, filename, mimetype=mimetype)
+
+
+@app.route("/transcript/<channel_slug>/<meeting_id>")
+def serve_transcript(channel_slug, meeting_id):
+    """Render a transcript as a readable HTML page with per-segment anchors.
+
+    URL fragment ``#t<seconds>`` scrolls to (and highlights) the matching
+    segment, e.g. ``/transcript/my_channel/2026-03-14_abc123#t120``.
+    """
+    import re as _re
+    transcript_path = STORAGE_ROOT / channel_slug / meeting_id / "transcript.txt"
+    if not transcript_path.exists():
+        abort(404)
+
+    raw = transcript_path.read_text(encoding="utf-8")
+    segments = []
+    for line in raw.splitlines():
+        m = _re.match(r"^(\d+)s\s+-->\s+(.*)", line)
+        if m:
+            segments.append({"seconds": int(m.group(1)), "text": m.group(2)})
+
+    # Derive a human-readable title from the meeting directory name
+    meeting_label = meeting_id.replace("_", " — ", 1)
+
+    return render_template(
+        "transcript.html",
+        channel_slug=channel_slug,
+        meeting_id=meeting_id,
+        meeting_label=meeting_label,
+        segments=segments,
+    )
 
 
 @app.route("/login", methods=["GET", "POST"])

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -27,6 +27,9 @@
       <p class="story-source">
         {{ story.channel_name }}{% if story.video_title %} &mdash; <em>{{ story.video_title }}</em>{% endif %}
         &mdash; <a class="story-watch" href="https://youtu.be/{{ story.video_id }}?t={{ story.start_seconds }}" target="_blank" rel="noopener">&#9654; Watch source</a>
+        {% if story.channel_slug and story.meeting_id %}
+        &mdash; <a class="story-transcript" href="{{ url_for('serve_transcript', channel_slug=story.channel_slug, meeting_id=story.meeting_id) }}#t{{ story.start_seconds }}" target="_blank" rel="noopener">&#128221; Read transcript</a>
+        {% endif %}
       </p>
       <div class="story-body">{{ story.body_html | safe }}</div>
     </article>

--- a/web/templates/transcript.html
+++ b/web/templates/transcript.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block title %}Transcript — {{ meeting_label }}{% endblock %}
+
+{% block content %}
+<style>
+  .transcript-page { max-width: 780px; margin: 0 auto; padding: 24px 16px 48px; }
+  .transcript-page h1 { font-size: 1.3em; margin-bottom: 4px; }
+  .transcript-page .back { font-size: 0.85em; margin-bottom: 20px; display: block; }
+  table.transcript { border-collapse: collapse; width: 100%; font-size: 0.93em; }
+  table.transcript td { padding: 5px 8px; vertical-align: top; line-height: 1.55; }
+  table.transcript td.ts { white-space: nowrap; color: #888; width: 5em; }
+  table.transcript td.ts a { color: #888; text-decoration: none; }
+  table.transcript td.ts a:hover { text-decoration: underline; }
+  table.transcript tr:target td { background: #fffbe6; }
+  table.transcript tr:nth-child(even) td { background: #f7f7f5; }
+  table.transcript tr:nth-child(even):target td { background: #fffbe6; }
+</style>
+
+<div class="transcript-page">
+  <h1>Transcript</h1>
+  <em>{{ meeting_label }}</em>
+  <br><br>
+  {% if segments %}
+  <table class="transcript">
+    {% for seg in segments %}
+    <tr id="t{{ seg.seconds }}">
+      <td class="ts">
+        <a href="#t{{ seg.seconds }}">{{ "%d:%02d"|format(seg.seconds // 60, seg.seconds % 60) }}</a>
+      </td>
+      <td>{{ seg.text }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+  {% else %}
+  <p>No transcript segments found.</p>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
- Replace 'GONZALES, Calif.' in the Gemini prompt with 'SPRINGFIELD, Mo.' to avoid a real city showing up verbatim in AI-generated datelines
- Add /transcript/<channel_slug>/<meeting_id> route that renders a meeting's transcript.txt as a readable HTML page with per-segment anchors (id="t<seconds>") and CSS :target highlighting
- Blog stories now carry channel_slug and meeting_id so transcript links can be built; both the Flask-rendered blog template and the static rebuild_user_blog HTML include a "Read transcript" link anchored to the relevant segment timestamp

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk