### PR TITLE
Add ntfy.sh push notifications for new story runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,7 @@ The `**Segment Start:**` value links back to the exact timestamp in the source Y
 | `feeds[].focus` | Yes | Topic guidance for the AI (e.g. "housing, zoning, permits") |
 | `base_url` | No | Public URL of `archive/rss.xml`, used as the meta-feed self-link |
 | `blog_days` | No | Days of stories to include in per-user blog pages (default: `90`) |
+| `ntfy_topic` | No | ntfy.sh topic for run-summary push notifications (e.g. `"TubeNewsAdmin"`); omit to disable |
 | `max_parallel_feeds` | No | Max channels processed concurrently (default: `3`; capped at number of feeds) |
 | `port` | No | Port the Flask web UI listens on (default: `8000`) |
 

--- a/TubeNews.json.sample
+++ b/TubeNews.json.sample
@@ -3,6 +3,7 @@
   "gemini_model": "gemini-2.5-flash",
   "supadata_api_key": "ADD_SUPADATA-KEY",
   "base_url": "",
+  "ntfy_topic": "TubeNewsAdmin",
   "blog_days": 90,
   "tubenews_key": "generate with: python -c 'import secrets; print(secrets.token_hex(32))'",
   "admin_emails": ["you@example.com"],

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -1103,6 +1103,31 @@ def process_feed(
 # ---------------------------------------------------------------------------
 
 
+def _send_ntfy(topic: str, total_stories: int, feed_results: list[dict], started_at: float) -> None:
+    """POST a run-summary notification to ntfy.sh/<topic>."""
+    import urllib.request as _urllib_request
+
+    timestamp = datetime.fromtimestamp(started_at).strftime("%B %-d, %Y at %-I:%M %p")
+    story_word = "story" if total_stories == 1 else "stories"
+    lines = [f"{total_stories} new {story_word} — {timestamp}"]
+    for r in feed_results:
+        if r["stories_written"]:
+            lines.append(f"  \u2022 {r['channel_name']}: {r['stories_written']}")
+    message = "\n".join(lines)
+
+    req = _urllib_request.Request(
+        f"https://ntfy.sh/{topic}",
+        data=message.encode(),
+        method="POST",
+        headers={"Title": "TubeNews", "Priority": "default"},
+    )
+    try:
+        _urllib_request.urlopen(req, timeout=10)
+        logger.debug(f"ntfy.sh/{topic}: notification sent")
+    except Exception as exc:
+        logger.warning(f"ntfy.sh/{topic}: notification failed: {exc}")
+
+
 def main() -> None:
     """Load config, process each feed, and rebuild RSS outputs."""
     parser = argparse.ArgumentParser(description="TubeNews — YouTube channel monitor")
@@ -1168,6 +1193,10 @@ def main() -> None:
         run_log_path.write_text(json.dumps(runs[-30:], indent=2))
     except Exception:
         pass
+
+    ntfy_topic = config.get("ntfy_topic")
+    if ntfy_topic and total_stories > 0:
+        _send_ntfy(ntfy_topic, total_stories, feed_results, started_at)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When ntfy_topic is set in TubeNews.json, a POST is sent to ntfy.sh/<topic> at the end of each run that produces at least one new story. The message includes the run timestamp and a per-channel breakdown. Uses stdlib urllib only — no new dependency.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk