### PR TITLE
Rename admin_emails config key to admin_users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,7 +399,7 @@ error and redirects to the dashboard instead.
 | GET | `/logout` | `logout` | Clears session |
 | GET | `/blog` | `serve_blog` | Regenerates and serves the logged-in user's blog |
 
-**Admin required (`admin_emails` in config):**
+**Admin required (`admin_users` in config):**
 
 | Method | Route | Handler | Description |
 |---|---|---|---|
@@ -422,7 +422,7 @@ error and redirects to the dashboard instead.
 - Login and register routes are rate-limited (flask-limiter).
 - `SESSION_COOKIE_SECURE` is only set when `TUBENEWS_HTTPS=true` is in the
   environment, so local dev works without HTTPS.
-- Admins are determined solely by email match against `admin_emails` in
+- Admins are determined solely by email match against `admin_users` in
   `TubeNews.json` — there is no `is_admin` flag stored in `user.json`.
 - Locked accounts (`"locked": true`) fail `is_active` and are rejected by
   flask-login on every request without needing to log out.

--- a/SERVING.md
+++ b/SERVING.md
@@ -48,7 +48,7 @@ Add your email to `TubeNews.json`:
 
 ```json
 {
-  "admin_emails": ["you@example.com"],
+  "admin_users": ["you@example.com"],
   ...
 }
 ```
@@ -60,7 +60,7 @@ python web/app.py
 ```
 
 Open `http://your-server:8000` in a browser (default port; change with `"port"` in `TubeNews.json`). Register an account — your email
-matches `admin_emails` so you will have admin access automatically.
+matches `admin_users` so you will have admin access automatically.
 
 ### 5. Set base_url
 

--- a/TubeNews.json.sample
+++ b/TubeNews.json.sample
@@ -6,7 +6,7 @@
   "ntfy_topic": "TubeNewsAdmin",
   "blog_days": 90,
   "tubenews_key": "generate with: python -c 'import secrets; print(secrets.token_hex(32))'",
-  "admin_emails": ["you@example.com"],
+  "admin_users": ["you@example.com"],
   "feeds": [
     {
       "channel_id": "CHANNEL-ID",

--- a/web/app.py
+++ b/web/app.py
@@ -130,7 +130,7 @@ class User(UserMixin):
     def is_admin(self) -> bool:
         try:
             cfg = json.loads(CONFIG_FILE.read_text())
-            return self.email in [e.strip().lower() for e in cfg.get("admin_emails", [])]
+            return self.email in [e.strip().lower() for e in cfg.get("admin_users", [])]
         except Exception:
             return False
 
@@ -683,14 +683,14 @@ def admin_user_promote(uid: str):
         flash("You cannot change your own admin status.", "error")
         return redirect(url_for("admin_user", uid=uid))
     cfg = _load_config()
-    admin_emails = [e.strip().lower() for e in cfg.get("admin_emails", [])]
-    if user.email in admin_emails:
-        admin_emails.remove(user.email)
+    admin_users = [e.strip().lower() for e in cfg.get("admin_users", [])]
+    if user.email in admin_users:
+        admin_users.remove(user.email)
         flash(f"Admin access revoked for {user.email}.", "success")
     else:
-        admin_emails.append(user.email)
+        admin_users.append(user.email)
         flash(f"{user.email} is now an admin.", "success")
-    cfg["admin_emails"] = admin_emails
+    cfg["admin_users"] = admin_users
     CONFIG_FILE.write_text(json.dumps(cfg, indent=2))
     return redirect(url_for("admin_user", uid=uid))
 


### PR DESCRIPTION
The list contains usernames (which happen to be emails), not email addresses per se. The new name better reflects the intent.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk