### PR TITLE
Add per-user font size and dark mode display preferences

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -250,6 +250,27 @@ def _blog_url(token: str) -> str:
     return url_for("serve_blog_public", token=token, _external=True).replace(f"/blog/{token}", f"/blog/{token}.html")
 
 
+def _prefs_to_classes(prefs: dict) -> str:
+    """Convert a user preferences dict to an HTML class string for <html>."""
+    classes = []
+    if prefs.get("dark_mode"):
+        classes.append("dark")
+    fs = prefs.get("font_size", "normal")
+    if fs in ("large", "larger"):
+        classes.append(f"font-{fs}")
+    return " ".join(classes)
+
+
+@app.context_processor
+def inject_body_classes():
+    """Make body_classes available in every template for the logged-in user."""
+    if current_user.is_authenticated:
+        classes = _prefs_to_classes(current_user._data.get("preferences", {}))
+    else:
+        classes = ""
+    return {"body_classes": classes}
+
+
 @app.template_filter("format_ts")
 def format_ts(ts: int) -> str:
     if not ts:
@@ -563,6 +584,16 @@ def dashboard():
     channels = sorted(_load_channels(), key=lambda ch: ch.get("channel_name", "").lower())
 
     if request.method == "POST":
+        if request.form.get("action") == "prefs":
+            font_size = request.form.get("font_size", "normal")
+            if font_size not in ("normal", "large", "larger"):
+                font_size = "normal"
+            dark_mode = "dark_mode" in request.form
+            current_user._data["preferences"] = {"font_size": font_size, "dark_mode": dark_mode}
+            current_user._save()
+            flash("Display preferences saved.", "success")
+            return redirect(url_for("dashboard"))
+
         selected = set(request.form.getlist("channel_ids"))
         valid_ids = {ch["channel_id"] for ch in channels}
         current_user.set_channel_ids(sorted(selected & valid_ids))
@@ -572,12 +603,14 @@ def dashboard():
         flash("Subscriptions updated.", "success")
         return redirect(url_for("dashboard"))
 
+    prefs = current_user._data.get("preferences", {})
     return render_template(
         "dashboard.html",
         channels=channels,
         subscribed=set(current_user.channel_ids),
         feed_url=_feed_url(current_user.feed_token),
         blog_url=_blog_url(current_user.feed_token) if current_user.channel_ids else None,
+        prefs=prefs,
     )
 
 
@@ -621,7 +654,8 @@ def serve_blog_public(token: str):
                 stories = _get_user_stories(data, cfg.get("blog_days", 90))
                 blog_name = data.get("blog_name") or f"{data['name']}'s TubeNews"
                 return render_template("blog.html", stories=stories, blog_name=blog_name,
-                                       feed_path=f"/feed/{token}.xml")
+                                       feed_path=f"/feed/{token}.xml",
+                                       body_classes=_prefs_to_classes(data.get("preferences", {})))
         except Exception:
             continue
     abort(404)

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -19,9 +19,38 @@
   --max-w: 640px;
 }
 
+/* Font size preference — set on <html> so rem values throughout scale */
+html.font-large  { font-size: 20px; }
+html.font-larger { font-size: 24px; }
+
+/* Dark mode — override every CSS variable */
+html.dark {
+  --bg: #111827;
+  --surface: #1f2937;
+  --border: #374151;
+  --text: #f9fafb;
+  --muted: #9ca3af;
+  --accent: #60a5fa;
+  --accent-hover: #3b82f6;
+  --danger: #f87171;
+  --success-bg: #064e3b;
+  --success-text: #6ee7b7;
+  --error-bg: #7f1d1d;
+  --error-text: #fca5a5;
+  --info-bg: #1e3a5f;
+  --info-text: #93c5fd;
+}
+
+/* Fix hardcoded colours that don't use variables */
+html.dark .danger-zone           { border-color: #7f1d1d; background: #1f1414; }
+html.dark .user-table tbody tr:hover { background: #374151; }
+html.dark .pill-active           { background: #064e3b; color: #6ee7b7; }
+html.dark .pill-locked           { background: #7f1d1d; color: #fca5a5; }
+html.dark .pill-admin            { background: #1e3a5f; color: #93c5fd; }
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 1.5;
   color: var(--text);
   background: var(--bg);
@@ -174,6 +203,13 @@ input[type="text"]:focus {
   font-size: 0.95rem;
   font-weight: 400;
   cursor: pointer;
+}
+
+.radio-group {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.25rem;
 }
 
 button[type="submit"],

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="{{ body_classes }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -63,6 +63,43 @@
       <p class="muted">No channels are configured in TubeNews.json yet.</p>
     {% endif %}
   </section>
+
+  <section>
+    <h2>Display</h2>
+    <form method="post">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="action" value="prefs">
+
+      <div class="form-row">
+        <label>Text size</label>
+        <div class="radio-group">
+          <label class="checkbox-label">
+            <input type="radio" name="font_size" value="normal"
+                   {% if prefs.get('font_size', 'normal') == 'normal' %}checked{% endif %}>
+            Normal
+          </label>
+          <label class="checkbox-label">
+            <input type="radio" name="font_size" value="large"
+                   {% if prefs.get('font_size') == 'large' %}checked{% endif %}>
+            Large
+          </label>
+          <label class="checkbox-label">
+            <input type="radio" name="font_size" value="larger"
+                   {% if prefs.get('font_size') == 'larger' %}checked{% endif %}>
+            Largest
+          </label>
+        </div>
+      </div>
+
+      <label class="checkbox-label" style="margin-top:0.5rem;">
+        <input type="checkbox" name="dark_mode"
+               {% if prefs.get('dark_mode') %}checked{% endif %}>
+        Dark mode
+      </label>
+
+      <button type="submit" class="btn-save">Save display preferences</button>
+    </form>
+  </section>
 </div>
 
 <script>


### PR DESCRIPTION
user.json: preferences stored as {"font_size": "normal|large|larger",
"dark_mode": true|false}.

app.py:
- _prefs_to_classes() converts prefs dict to HTML class string ("dark", "font-large", "font-larger")
- Context processor injects body_classes into every template for the logged-in user automatically
- dashboard POST: action=prefs branch saves font_size + dark_mode; existing subscription logic unchanged
- serve_blog_public: passes blog owner's preferences as body_classes so the public blog reflects how its owner configured it

base.html: class="{{ body_classes }}" on <html> element

style.css:
- body font-size changed from 16px to 1rem so html-level font-size classes cascade correctly through all rem-based measurements
- html.font-large (20px) and html.font-larger (24px) rules
- html.dark overrides all CSS variables for dark mode
- Fixed five hardcoded colour values that don't use variables (danger-zone, table hover, pill variants)
- .radio-group helper for the preferences form layout

dashboard.html: new Display section with Text size radio group (Normal / Large / Largest) and Dark mode checkbox; uses a separate form with action=prefs so the Subscribe button is unaffected.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk