### PR TITLE
Add admin Add User form to the users page

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -856,6 +856,40 @@ def admin_user_delete(uid: str):
 # ---------------------------------------------------------------------------
 
 
+@app.route("/admin/users/add", methods=["POST"])
+@login_required
+@admin_required
+def admin_user_add():
+    name = request.form.get("name", "").strip()
+    email = request.form.get("email", "").strip().lower()
+    password = request.form.get("password", "")
+
+    if not name:
+        flash("Name is required.", "error")
+    elif not email or "@" not in email or "." not in email.split("@")[-1]:
+        flash("Please enter a valid email address.", "error")
+    elif len(password) < 10:
+        flash("Password must be at least 10 characters.", "error")
+    elif _find_user_by_email(email):
+        flash(f"An account with {email} already exists.", "error")
+    else:
+        user_uuid = str(uuid.uuid4())
+        user_dir = USERS_ROOT / user_uuid
+        user_dir.mkdir(parents=True, exist_ok=True)
+        data = {
+            "name": name,
+            "email": email,
+            "password_hash": generate_password_hash(password),
+            "channel_ids": [],
+            "feed_token": str(uuid.uuid4()),
+            "created_at": int(datetime.now(timezone.utc).timestamp()),
+        }
+        (user_dir / "user.json").write_text(json.dumps(data, indent=2))
+        flash(f"Account created for {name} ({email}).", "success")
+
+    return redirect(url_for("admin_users"))
+
+
 @app.route("/admin/runs")
 @login_required
 @admin_required

--- a/web/templates/admin_users.html
+++ b/web/templates/admin_users.html
@@ -5,6 +5,26 @@
 <div class="admin">
   <h1>Users <span class="badge">{{ users|length }}</span></h1>
 
+  <div class="admin-section" id="add-user-section">
+    <h2>Add user</h2>
+    <form method="post" action="{{ url_for('admin_user_add') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="form-row">
+        <label for="new-name">Name</label>
+        <input type="text" id="new-name" name="name" autocomplete="off" required>
+      </div>
+      <div class="form-row">
+        <label for="new-email">Email</label>
+        <input type="email" id="new-email" name="email" autocomplete="off" required>
+      </div>
+      <div class="form-row">
+        <label for="new-password">Password <span class="hint">(min 10 characters — share with the user and ask them to change it)</span></label>
+        <input type="text" id="new-password" name="password" autocomplete="off" required minlength="10">
+      </div>
+      <button type="submit" class="btn-save">Create account</button>
+    </form>
+  </div>
+
   {% if users %}
   <table class="user-table">
     <thead>


### PR DESCRIPTION
New POST /admin/users/add route creates an account without displacing the admin's own session (unlike the public /register which logs the new user in). Validates name, email format, minimum password length (10 chars), and duplicate-email check — same rules as self-registration.

admin_users.html: Add User section with name, email, and plaintext password field sits above the user table. Password is plaintext so the admin can read it aloud or copy it to share; the stored value is always hashed. Hint text reminds admin to ask the new user to change it.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk