### PR TITLE
Add display preferences section to admin edit-user page

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -778,6 +778,23 @@ def admin_user_password(uid: str):
     return redirect(url_for("admin_user", uid=uid))
 
 
+@app.route("/admin/user/<uid>/prefs", methods=["POST"])
+@login_required
+@admin_required
+def admin_user_prefs(uid: str):
+    user = _find_user_by_id(uid)
+    if not user:
+        abort(404)
+    font_size = request.form.get("font_size", "normal")
+    if font_size not in ("normal", "large", "larger"):
+        font_size = "normal"
+    dark_mode = "dark_mode" in request.form
+    user._data["preferences"] = {"font_size": font_size, "dark_mode": dark_mode}
+    user._save()
+    flash("Display preferences updated.", "success")
+    return redirect(url_for("admin_user", uid=uid))
+
+
 @app.route("/admin/user/<uid>/lock", methods=["POST"])
 @login_required
 @admin_required

--- a/web/templates/admin_user.html
+++ b/web/templates/admin_user.html
@@ -63,6 +63,38 @@
     {% endif %}
   </section>
 
+  <!-- ── Display preferences ───────────────────────────────────── -->
+  <section class="admin-section">
+    <h2>Display preferences</h2>
+    <form method="post" action="{{ url_for('admin_user_prefs', uid=u.get_id()) }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="form-row">
+        <label>Text size</label>
+        <div class="radio-group">
+          {% set fs = u._data.get('preferences', {}).get('font_size', 'normal') %}
+          <label class="checkbox-label">
+            <input type="radio" name="font_size" value="normal" {% if fs == 'normal' %}checked{% endif %}>
+            Normal
+          </label>
+          <label class="checkbox-label">
+            <input type="radio" name="font_size" value="large" {% if fs == 'large' %}checked{% endif %}>
+            Large
+          </label>
+          <label class="checkbox-label">
+            <input type="radio" name="font_size" value="larger" {% if fs == 'larger' %}checked{% endif %}>
+            Largest
+          </label>
+        </div>
+      </div>
+      <label class="checkbox-label" style="margin-top:0.5rem;">
+        <input type="checkbox" name="dark_mode"
+               {% if u._data.get('preferences', {}).get('dark_mode') %}checked{% endif %}>
+        Dark mode
+      </label>
+      <button type="submit">Save display preferences</button>
+    </form>
+  </section>
+
   <!-- ── RSS feed ──────────────────────────────────────────────── -->
   <section class="admin-section">
     <h2>RSS feed URL</h2>


### PR DESCRIPTION
New POST /admin/user/<uid>/prefs route saves font_size and dark_mode to the target user's preferences dict — same logic as the user's own dashboard, but admin-only and applies to any account.

admin_user.html: Display preferences section (text size radios + dark mode checkbox) inserted between Subscriptions and RSS feed, pre-filled from the user's current preferences.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk