### PR TITLE
Fix feed and blog URLs generating absolute https links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,6 +443,16 @@ the web app does **not** call either — the web UI uses dynamic generation only
 
 ---
 
+## URL Generation Rules
+
+**Never use `_external=True` with `url_for()`** in the web UI. The deployment does not yet have HTTPS configured, and `_external=True` produces absolute URLs (with scheme and host) that break when the scheme or host is wrong.
+
+- `_feed_url(token)` and `_blog_url(token)` return relative paths (`/feed/<token>.xml`, `/blog/<token>.html`) when `base_url` is not set in `TubeNews.json`. They only prepend an absolute base when the operator has explicitly configured `base_url`.
+- All links rendered in HTML templates must be relative (use `url_for()` without `_external=True`, or hardcoded root-relative paths like `/feed/...`).
+- The only place absolute URLs are appropriate is inside generated RSS/Atom XML, and only when `base_url` is configured.
+
+---
+
 ## Commit & Branch Conventions
 
 This project uses descriptive commit messages. When working on this repo as an AI assistant, push to the branch specified in the task instructions. Never push to `main` directly.

--- a/web/app.py
+++ b/web/app.py
@@ -240,14 +240,14 @@ def _feed_url(token: str) -> str:
     base = _base_url()
     if base:
         return f"{base}/feed/{token}.xml"
-    return url_for("serve_feed", token=token, _external=True).replace(f"/feed/{token}", f"/feed/{token}.xml")
+    return f"/feed/{token}.xml"
 
 
 def _blog_url(token: str) -> str:
     base = _base_url()
     if base:
         return f"{base}/blog/{token}.html"
-    return url_for("serve_blog_public", token=token, _external=True).replace(f"/blog/{token}", f"/blog/{token}.html")
+    return f"/blog/{token}.html"
 
 
 def _prefs_to_classes(prefs: dict) -> str:


### PR DESCRIPTION
_feed_url() and _blog_url() were calling url_for(..., _external=True) as their no-base_url fallback, producing absolute URLs with whatever scheme Flask detected. Without HTTPS configured this is broken.

Fix: when base_url is not set, return simple root-relative paths (/feed/<token>.xml, /blog/<token>.html). Absolute URLs are only constructed when the operator has explicitly set base_url in config.

Added a "URL Generation Rules" section to CLAUDE.md documenting that _external=True must not be used in this codebase and explaining when absolute vs relative URLs are appropriate.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk