### PR TITLE
Remove blog_days date filter — blog now shows all stories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,6 @@ The `**Segment Start:**` value links back to the exact timestamp in the source Y
 | `archive_dir` | No | Path to the archive directory (default: `archive/` next to `TubeNews.py`). Use an absolute path (e.g. `/var/www/html/tubenews`) or a path relative to `TubeNews.py` to point the archive at your web server's document root |
 | `request_timeout` | No | Seconds before giving up on YouTube scrape and Supadata API calls (default: `15`). Increase on slow or high-latency connections |
 | `base_url` | No | Public URL of `archive/rss.xml`, used as the meta-feed self-link |
-| `blog_days` | No | Days of stories to include in per-user blog pages (default: `90`) |
 | `ntfy_topic` | No | ntfy.sh topic for run-summary push notifications (e.g. `"TubeNewsAdmin"`); omit to disable |
 | `max_parallel_feeds` | No | Max channels processed concurrently (default: `3`; capped at number of feeds) |
 | `port` | No | Port the Flask web UI listens on (default: `8000`) |
@@ -367,8 +366,8 @@ Both the feed and blog are generated fresh on each request from the live archive
 3. XML bytes returned directly as the HTTP response — nothing written to disk
 
 **Blog** (`/blog/<token>.html` and logged-in `/blog`):
-1. `_get_user_stories()` scans `archive/` and returns stories from the user's
-   subscribed channels processed within the last `blog_days` days
+1. `_get_user_stories()` scans `archive/` and returns all stories from the user's
+   subscribed channels
 2. Flask renders `blog.html` with the story list and returns HTML
 
 Because both read the archive on every request, they always reflect the latest

--- a/TubeNews.json.sample
+++ b/TubeNews.json.sample
@@ -6,7 +6,6 @@
   "archive_dir": "",
   "request_timeout": 15,
   "ntfy_topic": "TubeNewsAdmin",
-  "blog_days": 90,
   "tubenews_key": "generate with: python -c 'import secrets; print(secrets.token_hex(32))'",
   "admin_users": ["you@example.com"],
   "feeds": [

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -739,18 +739,16 @@ def rebuild_user_feed(user: dict, base_url: str = "", user_id: str = "") -> None
     (user_dir / "rss.xml").write_bytes(xml_bytes)
 
 
-def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_id: str = "") -> None:
+def rebuild_user_blog(user: dict, base_url: str = "", user_id: str = "") -> None:
     """Generate ``archive/users/<id>/index.html`` — a static blog page for a user.
 
     Pulls stories from the user's subscribed channels (same logic as
     :func:`rebuild_user_feed`) and renders them as a self-contained HTML page
-    sorted newest-first.  Only stories processed within the last *blog_days* days
-    are included so the page stays a manageable size.
+    sorted newest-first.  All stories are included regardless of age.
 
     Args:
         user:      User config dict from ``archive/users/<id>/user.json``.
         base_url:  Public URL root; used to build a self-link in the page header.
-        blog_days: How many days of stories to include (default 90).
         user_id:   UUID directory name for the user. Falls back to slugify(name) if omitted.
     """
     name = user["name"]
@@ -759,8 +757,6 @@ def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_
     user_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info(f"TubeNews: Rebuilding blog for {name}")
-
-    cutoff = time.time() - blog_days * 86400
 
     all_stories: list[dict] = []
     for channel_dir in [d for d in STORAGE_ROOT.iterdir() if d.is_dir() and d.name != "users"]:
@@ -781,8 +777,6 @@ def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_
             try:
                 metadata = json.loads(metadata_path.read_text())
                 if metadata.get("status") == "ignored_too_old":
-                    continue
-                if metadata.get("processed_at", 0) < cutoff:
                     continue
                 for story_file in meeting_dir.glob("[0-9]*.md"):
                     all_stories.append({"file": story_file, "meta": metadata, "channel_name": channel_name,
@@ -843,8 +837,7 @@ def rebuild_user_blog(user: dict, base_url: str = "", blog_days: int = 90, user_
 
     page_title = user.get("blog_name") or f"TubeNews — {name}"
     meta_line = (
-        f"{len(all_stories)} stories from {len(subscribed)} channel{'s' if len(subscribed) != 1 else ''} "
-        f"— last {blog_days} days"
+        f"{len(all_stories)} stories from {len(subscribed)} channel{'s' if len(subscribed) != 1 else ''}"
     )
     rss_feed_path = f"/feed/{user['feed_token']}.xml"
     rss_link = f'<link rel="alternate" type="application/rss+xml" title="{page_title}" href="{rss_feed_path}">'

--- a/tests/test_tubenews.py
+++ b/tests/test_tubenews.py
@@ -581,14 +581,13 @@ def test_rebuild_user_blog_excludes_unsubscribed_stories(user_archive):
     content = (user_archive / "users" / "Jane_Doe" / "index.html").read_text()
     assert "Beta City Council" not in content
 
-def test_rebuild_user_blog_date_filter(tmp_path, monkeypatch):
-    """Stories older than blog_days should be omitted."""
+def test_rebuild_user_blog_includes_old_stories(tmp_path, monkeypatch):
+    """Stories from years ago must appear in the blog — no date filter."""
     import TubeNews
     monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
 
     channel_dir = tmp_path / "old_channel"
     meeting_dir = _make_meeting(channel_dir, "2020-01-01", "VIDold12345", "Old Meeting")
-    # Override processed_at to a timestamp well in the past.
     old_meta = {
         "video_id": "VIDold12345",
         "video_title": "Old Meeting",
@@ -603,9 +602,9 @@ def test_rebuild_user_blog_date_filter(tmp_path, monkeypatch):
     )
 
     user = {"name": "Test User", "channel_ids": ["UC_OLD_ID"], "feed_token": "test-token-2"}
-    rebuild_user_blog(user, blog_days=90)  # only 90 days; story is 200 days old
+    rebuild_user_blog(user)
     content = (tmp_path / "users" / "Test_User" / "index.html").read_text()
-    assert "Very Old Story" not in content
+    assert "Very Old Story" in content
 
 
 # ---------------------------------------------------------------------------
@@ -815,9 +814,8 @@ def test_feed_and_blog_empty_when_no_subscriptions(parity_archive):
     assert "Channel B" not in blog_html
 
 
-def test_blog_date_filter_does_not_affect_feed(tmp_path, monkeypatch):
-    """An old story (beyond blog_days) is absent from the blog but still present
-    in the RSS feed, which has no date filter."""
+def test_old_stories_appear_in_both_feed_and_blog(tmp_path, monkeypatch):
+    """Old stories must appear in both the RSS feed and the blog — neither has a date filter."""
     import TubeNews
     monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
 
@@ -839,11 +837,11 @@ def test_blog_date_filter_does_not_affect_feed(tmp_path, monkeypatch):
     user = {"name": "Time", "channel_ids": ["UC_OLD_ID"], "feed_token": "time-tok"}
 
     feed_xml = build_user_feed_xml(user).decode()
-    rebuild_user_blog(user, blog_days=90)
+    rebuild_user_blog(user)
     blog_html = (tmp_path / "users" / "Time" / "index.html").read_text()
 
-    assert "Ancient Story" in feed_xml,      "Feed has no date filter — old stories must still appear"
-    assert "Ancient Story" not in blog_html, "Blog date filter must exclude old stories"
+    assert "Ancient Story" in feed_xml,  "Old stories must appear in RSS feed"
+    assert "Ancient Story" in blog_html, "Old stories must appear in blog — no date filter"
 
 
 # ---------------------------------------------------------------------------

--- a/web/app.py
+++ b/web/app.py
@@ -411,10 +411,9 @@ def _get_channel_stories(channel_id: str) -> tuple[str | None, list[dict]]:
     return None, []
 
 
-def _get_user_stories(user_data: dict, blog_days: int = 90) -> list[dict]:
+def _get_user_stories(user_data: dict) -> list[dict]:
     """Return parsed stories for a user's subscribed channels, newest-first."""
     subscribed = set(user_data.get("channel_ids", []))
-    cutoff = time.time() - blog_days * 86400
     raw: list[dict] = []
     channels_cfg = _load_channels()
     for channel_dir in [d for d in STORAGE_ROOT.iterdir() if d.is_dir() and d.name != "users"]:
@@ -429,8 +428,6 @@ def _get_user_stories(user_data: dict, blog_days: int = 90) -> list[dict]:
             try:
                 meta = json.loads(meta_path.read_text())
                 if meta.get("status") == "ignored_too_old":
-                    continue
-                if meta.get("processed_at", 0) < cutoff:
                     continue
                 for story_file in meeting_dir.glob("[0-9]*.md"):
                     raw.append({"file": story_file, "meta": meta, "channel_name": channel_name,
@@ -651,7 +648,7 @@ def serve_blog_public(token: str):
             data = json.loads(user_json.read_text())
             if data.get("feed_token") == token:
                 cfg = _load_config()
-                stories = _get_user_stories(data, cfg.get("blog_days", 90))
+                stories = _get_user_stories(data)
                 blog_name = data.get("blog_name") or f"{data['name']}'s TubeNews"
                 return render_template("blog.html", stories=stories, blog_name=blog_name,
                                        feed_path=f"/feed/{token}.xml",
@@ -669,7 +666,7 @@ def serve_blog():
         flash("Subscribe to channels to start reading your blog.", "info")
         return redirect(url_for("dashboard"))
     cfg = _load_config()
-    stories = _get_user_stories(current_user._data, cfg.get("blog_days", 90))
+    stories = _get_user_stories(current_user._data)
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
     return render_template("blog.html", stories=stories, blog_name=blog_name,
                            feed_path=f"/feed/{current_user.feed_token}.xml")


### PR DESCRIPTION
The blog (web dynamic and CLI static) previously excluded stories older than blog_days (default 90). Changed to include all stories regardless of age, matching user preference.

- web/app.py: _get_user_stories() drops blog_days param and cutoff check
- web/app.py: serve_blog_public and serve_blog callers updated
- TubeNews.py: rebuild_user_blog() drops blog_days param and cutoff; meta line no longer says "last N days"
- TubeNews.json.sample: remove blog_days key
- CLAUDE.md: remove blog_days config reference; update _get_user_stories docs
- tests: two tests that asserted old stories were absent flipped to assert they are present; rebuild_user_blog() calls updated to drop blog_days arg

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk