### PR TITLE
feat: move blog source links to own line; add transcript banner with …

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -543,7 +543,20 @@ button.btn-danger-sm:hover { background: #fee2e2; }
 .story-source {
   font-size: 0.82rem;
   color: var(--muted);
+  margin-bottom: 0.2rem;
+}
+
+.story-links {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: nowrap;
   margin-bottom: 0.75rem;
+}
+
+.story-links-sep {
+  color: var(--muted);
+  font-size: 0.8rem;
 }
 
 .story-body p {
@@ -553,11 +566,10 @@ button.btn-danger-sm:hover { background: #fee2e2; }
 
 .story-watch,
 .story-transcript {
-  display: inline-block;
-  margin-top: 0.75rem;
   font-size: 0.85rem;
   color: var(--danger);
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .story-watch:hover,

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -15,9 +15,12 @@
       <p class="story-dateline">{{ story.dateline }}</p>
       <p class="story-source">
         {{ story.channel_name }}{% if story.video_title %} &mdash; <em>{{ story.video_title }}</em>{% endif %}
-        &mdash; <a class="story-watch" href="https://youtu.be/{{ story.video_id }}?t={{ story.start_seconds }}" target="_blank" rel="noopener">&#9654; Watch source</a>
+      </p>
+      <p class="story-links">
+        <a class="story-watch" href="https://youtu.be/{{ story.video_id }}?t={{ story.start_seconds }}" target="_blank" rel="noopener">&#9654; Watch source</a>
         {% if story.channel_slug and story.meeting_id %}
-        &mdash; <a class="story-transcript" href="{{ url_for('serve_transcript', channel_slug=story.channel_slug, meeting_id=story.meeting_id) }}#t{{ story.start_seconds }}" target="_blank" rel="noopener">&#128221; Read transcript</a>
+        <span class="story-links-sep">&middot;</span>
+        <a class="story-transcript" href="{{ url_for('serve_transcript', channel_slug=story.channel_slug, meeting_id=story.meeting_id) }}#t{{ story.start_seconds }}" target="_blank" rel="noopener">&#128221; Read transcript</a>
         {% endif %}
       </p>
       <div class="story-body">{{ story.body_html | safe }}</div>

--- a/web/templates/transcript.html
+++ b/web/templates/transcript.html
@@ -3,9 +3,33 @@
 
 {% block content %}
 <style>
+  .transcript-banner {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 16px;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
+  }
+  .transcript-banner .tb-brand { font-weight: 600; color: var(--fg); }
+  .transcript-banner .tb-label { color: var(--muted); margin-left: 0.6em; }
+  .transcript-banner .tb-close {
+    padding: 4px 14px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--fg);
+    font-size: 0.85rem;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .transcript-banner .tb-close:hover { background: var(--accent-bg, #f0f0f0); }
   .transcript-page { max-width: 780px; margin: 0 auto; padding: 24px 16px 48px; }
   .transcript-page h1 { font-size: 1.3em; margin-bottom: 4px; }
-  .transcript-page .back { font-size: 0.85em; margin-bottom: 20px; display: block; }
   table.transcript { border-collapse: collapse; width: 100%; font-size: 0.93em; }
   table.transcript td { padding: 5px 8px; vertical-align: top; line-height: 1.55; }
   table.transcript td.ts { white-space: nowrap; color: #888; width: 5em; }
@@ -18,6 +42,14 @@
   html.dark table.transcript tr:target td,
   html.dark table.transcript tr:nth-child(even):target td { background: #3b3200; }
 </style>
+
+<div class="transcript-banner">
+  <span>
+    <span class="tb-brand">TubeNews</span>
+    <span class="tb-label">— {{ meeting_label }}</span>
+  </span>
+  <button class="tb-close" onclick="window.close()">Close transcript ✕</button>
+</div>
 
 <div class="transcript-page">
   <h1>Transcript</h1>


### PR DESCRIPTION
…close button

Blog:
- Watch source and Read transcript move from inline with channel/title to a dedicated .story-links row below, keeping them together with nowrap so they never split across lines mid-link

Transcript:
- Sticky top banner shows TubeNews branding and the meeting label so users know where they are and where the page came from
- "Close transcript ✕" button calls window.close() — gives non-technical users a clear action to take when finished; remains visible while scrolling

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk