### PR TITLE
feat: improve transcript page header with feed name, video title, and…

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -500,7 +500,8 @@ def serve_transcript(channel_slug, meeting_id):
     segment, e.g. ``/transcript/my_channel/2026-03-14_abc123#t120``.
     """
     import re as _re
-    transcript_path = STORAGE_ROOT / channel_slug / meeting_id / "transcript.txt"
+    meeting_dir = STORAGE_ROOT / channel_slug / meeting_id
+    transcript_path = meeting_dir / "transcript.txt"
     if not transcript_path.exists():
         abort(404)
 
@@ -511,14 +512,37 @@ def serve_transcript(channel_slug, meeting_id):
         if m:
             segments.append({"seconds": int(m.group(1)), "text": m.group(2)})
 
-    # Derive a human-readable title from the meeting directory name
-    meeting_label = meeting_id.replace("_", " — ", 1)
+    # Read video title and ID from metadata.json
+    video_title = None
+    video_id = None
+    meta_path = meeting_dir / "metadata.json"
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text())
+            video_title = meta.get("video_title") or None
+            video_id = meta.get("video_id") or None
+        except Exception:
+            pass
+    # Fall back to extracting video_id from the directory name
+    if not video_id and "_" in meeting_id:
+        video_id = meeting_id.split("_", 1)[1]
+
+    # Read channel name from channel.json written by rebuild_feed
+    channel_name = None
+    channel_json = STORAGE_ROOT / channel_slug / "channel.json"
+    if channel_json.exists():
+        try:
+            channel_name = json.loads(channel_json.read_text()).get("channel_name")
+        except Exception:
+            pass
 
     return render_template(
         "transcript.html",
         channel_slug=channel_slug,
         meeting_id=meeting_id,
-        meeting_label=meeting_label,
+        channel_name=channel_name or channel_slug.replace("_", " "),
+        video_title=video_title or meeting_id,
+        video_id=video_id,
         segments=segments,
     )
 

--- a/web/templates/transcript.html
+++ b/web/templates/transcript.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Transcript — {{ meeting_label }}{% endblock %}
+{% block title %}Transcript — {{ video_title }}{% endblock %}
 
 {% block content %}
 <style>
@@ -29,7 +29,10 @@
   }
   .transcript-banner .tb-close:hover { background: var(--accent-bg, #f0f0f0); }
   .transcript-page { max-width: 780px; margin: 0 auto; padding: 24px 16px 48px; }
-  .transcript-page h1 { font-size: 1.3em; margin-bottom: 4px; }
+  .transcript-page h1 { font-size: 1.3em; margin-bottom: 6px; }
+  .transcript-meta { font-size: 0.85rem; color: #888; margin-bottom: 20px; }
+  .transcript-yt { color: var(--danger, #c0392b); text-decoration: none; }
+  .transcript-yt:hover { text-decoration: underline; }
   table.transcript { border-collapse: collapse; width: 100%; font-size: 0.93em; }
   table.transcript td { padding: 5px 8px; vertical-align: top; line-height: 1.55; }
   table.transcript td.ts { white-space: nowrap; color: #888; width: 5em; }
@@ -46,15 +49,19 @@
 <div class="transcript-banner">
   <span>
     <span class="tb-brand">TubeNews</span>
-    <span class="tb-label">— {{ meeting_label }}</span>
+    <span class="tb-label">— {{ channel_name }}</span>
   </span>
   <button class="tb-close" onclick="window.close()">Close transcript ✕</button>
 </div>
 
 <div class="transcript-page">
-  <h1>Transcript</h1>
-  <em>{{ meeting_label }}</em>
-  <br><br>
+  <h1>{{ video_title }}</h1>
+  <p class="transcript-meta">
+    <span class="transcript-channel">{{ channel_name }}</span>
+    {% if video_id %}
+    &mdash; <a href="https://youtu.be/{{ video_id }}" target="_blank" rel="noopener" class="transcript-yt">&#9654; Watch on YouTube</a>
+    {% endif %}
+  </p>
   {% if segments %}
   <table class="transcript">
     {% for seg in segments %}


### PR DESCRIPTION
… YouTube link

The transcript page previously showed a raw directory name (date — video_id) as its only identifier. The route now reads metadata.json and channel.json to surface the actual video title and channel name.

- Sticky banner shows: TubeNews — [channel name]
- Page heading is the video title (falls back to meeting directory name)
- Subheading shows channel name and a Watch on YouTube link (opens original video)

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk