### PR TITLE
fix: use --accent for all links so dark mode is readable

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -56,6 +56,9 @@ body {
   background: var(--bg);
 }
 
+a { color: var(--accent); }
+a:visited { color: var(--accent); }
+
 /* Header */
 header {
   position: sticky;


### PR DESCRIPTION
Without a global a { color } rule, unclassed links fell back to the browser's built-in blue/purple which is illegible on dark backgrounds. Setting a, a:visited to var(--accent) means both light (#2563eb) and dark (#60a5fa) themes use the design's intended link colour everywhere, including the newly-added channel links on the runs page.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk