### PR TITLE
fix: form display:contents→inline-flex; Supadata balance caching; ❌ d…

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -1457,6 +1457,32 @@ def _main_body(args) -> None:
     if ntfy_topic and total_stories > 0:
         _send_ntfy(ntfy_topic, total_stories, feed_results, started_at)
 
+    _cache_supadata_balance(config)
+
+
+def _cache_supadata_balance(config: dict) -> None:
+    """Fetch Supadata credit usage and cache it to ``archive/supadata_balance.json``.
+
+    Called once at the end of each ``main()`` run so the web UI can read the
+    cached result instantly instead of making a live API call on every page load.
+    Silently skips if the API key is absent or the request fails.
+    """
+    key = config.get("supadata_api_key", "")
+    if not key:
+        return
+    try:
+        resp = requests.get(
+            "https://api.supadata.ai/v1/me",
+            headers={"x-api-key": key},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            (STORAGE_ROOT / "supadata_balance.json").write_text(
+                json.dumps(resp.json())
+            )
+    except Exception:
+        pass
+
 
 if __name__ == "__main__":
     main()

--- a/web/app.py
+++ b/web/app.py
@@ -17,7 +17,6 @@ import sys
 import time
 import uuid
 
-import requests
 from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path
@@ -1076,25 +1075,19 @@ def admin_run_now():
 
 
 def _get_supadata_balance() -> dict | None:
-    """Fetch credit usage from the Supadata /v1/me endpoint.
+    """Read cached Supadata credit usage from ``archive/supadata_balance.json``.
 
-    Returns a dict with ``plan``, ``usedCredits``, ``maxCredits`` on success,
-    or ``None`` if the key is not configured or the request fails.
+    The file is written by ``TubeNews._cache_supadata_balance()`` at the end of
+    each scraper run, so the web UI never blocks on a live API call.
+    Returns ``None`` if the file does not exist or cannot be parsed.
     """
-    key = _load_config().get("supadata_api_key", "")
-    if not key:
+    balance_path = STORAGE_ROOT / "supadata_balance.json"
+    if not balance_path.exists():
         return None
     try:
-        resp = requests.get(
-            "https://api.supadata.ai/v1/me",
-            headers={"x-api-key": key},
-            timeout=5,
-        )
-        if resp.status_code == 200:
-            return resp.json()
+        return json.loads(balance_path.read_text())
     except Exception:
-        pass
-    return None
+        return None
 
 
 @app.route("/admin/story/delete", methods=["POST"])

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -633,7 +633,7 @@ button.btn-danger-sm:hover { background: #fee2e2; }
   border-color: var(--text);
 }
 
-.share-delete-form { display: contents; }
+.share-delete-form { display: inline-flex; align-items: stretch; padding: 0; margin: 0; border: none; }
 .share-delete { color: #dc2626; border-color: #fca5a5; }
 .share-delete:hover { color: #fff !important; background: #dc2626 !important; border-color: #dc2626 !important; }
 

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -54,7 +54,7 @@
           <input type="hidden" name="channel_slug" value="{{ story.channel_slug }}">
           <input type="hidden" name="meeting_id" value="{{ story.meeting_id }}">
           <input type="hidden" name="filename" value="{{ story.story_filename }}">
-          <button type="submit" class="share-delete">Delete</button>
+          <button type="submit" class="share-delete">&#10060; Delete</button>
         </form>
         {% endif %}
       </div>


### PR DESCRIPTION
…elete button

Share-bar form on Safari (iPad): display:contents is unreliable for <form> elements in Safari/WebKit — when it falls back to display:block the form becomes a block-level flex item that breaks the rest of the flex row, which is why share buttons disappeared on iPad.  Replaced with display:inline-flex + align-items:stretch so the form is a proper inline flex item everywhere and the contained button is sized identically to the other share buttons.

Delete button: ❌ emoji prefix added as requested.

Supadata balance caching: _get_supadata_balance() in web/app.py was making a live HTTP request on every /admin/feeds page load (up to 5s timeout).  Moved the fetch to TubeNews.py: new _cache_supadata_balance() is called once at the end of main() and writes archive/supadata_balance.json. The web UI now reads that cached file — instant, no network call. Removed the now-unused `import requests` from web/app.py.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk