### PR TITLE
feat: nav badge for unseen channels (per-user seen tracking)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,13 +357,15 @@ archive/users/
   },
   "feed_token": "550e8400-e29b-41d4-a716-446655440000",
   "created_at": 1741910400,
-  "locked": false
+  "locked": false,
+  "seen_channel_ids": ["UCxxxxxxx", "UCyyyyyyy"]
 }
 ```
 
 - `channel_ids` — authoritative subscription list.
 - `channel_focus` — optional per-channel focus keywords set by the user on the dashboard. Each value is a **list of strings** (one per focus line, up to 3); old installs may store a plain string — both are handled transparently. Missing key or empty list means no filter (show all stories). `_collect_channel_focuses` reads this at processing time to determine which Gemini calls to make for each channel.
 - `feed_token` — UUID generated at registration; authenticates all public (no-login) URLs for that user. Rotating it invalidates both the RSS feed URL and the blog URL simultaneously.
+- `seen_channel_ids` — list of channel IDs the user has "seen" on the dashboard. The `inject_body_classes` context processor diffs this against the current feed list to compute `unseen_channel_count`, which drives the red badge on the "Settings" nav link. Key absent means not yet initialised (pre-feature users); treated as 0 unseen so existing users aren't badged on upgrade. Written (covering all current channels) whenever the user loads or saves the dashboard.
 
 ### Token Model
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -777,6 +777,116 @@ def test_dashboard_caps_focuses_at_three(logged_in_client, archive):
 
 
 # ---------------------------------------------------------------------------
+# Unseen-channel nav badge
+# ---------------------------------------------------------------------------
+
+def test_dashboard_get_initialises_seen_channel_ids(logged_in_client, archive):
+    """GET /dashboard writes seen_channel_ids covering all configured channels."""
+    import json as _json
+    import web.app as webapp
+
+    logged_in_client.get("/dashboard")
+
+    users_dir = webapp.STORAGE_ROOT / "users"
+    for uid_dir in users_dir.iterdir():
+        uj = uid_dir / "user.json"
+        if not uj.exists():
+            continue
+        d = _json.loads(uj.read_text())
+        if d.get("email") == "test@example.com":
+            assert set(d["seen_channel_ids"]) == {"UC_ALPHA_ID", "UC_BETA__ID"}
+            return
+    pytest.fail("User not found")
+
+
+def test_dashboard_post_sets_seen_channel_ids(logged_in_client, archive):
+    """POST /dashboard includes seen_channel_ids in the save."""
+    import json as _json
+    import web.app as webapp
+
+    logged_in_client.post("/dashboard", data={"channel_ids": ["UC_ALPHA_ID"]},
+                          follow_redirects=True)
+
+    users_dir = webapp.STORAGE_ROOT / "users"
+    for uid_dir in users_dir.iterdir():
+        uj = uid_dir / "user.json"
+        if not uj.exists():
+            continue
+        d = _json.loads(uj.read_text())
+        if d.get("email") == "test@example.com":
+            assert set(d["seen_channel_ids"]) == {"UC_ALPHA_ID", "UC_BETA__ID"}
+            return
+    pytest.fail("User not found")
+
+
+def test_nav_badge_shown_when_unseen_channel_exists(client, archive):
+    """Nav badge appears when a channel is not in user's seen_channel_ids."""
+    import json as _json
+    import web.app as webapp
+
+    # Create user subscribed to Alpha who has only "seen" Alpha (Beta is new to them)
+    users_dir = webapp.STORAGE_ROOT / "users"
+    _make_user(
+        users_dir, name="Partial User", email="partial@example.com",
+        channel_ids=["UC_ALPHA_ID"], token="partial-token-xyz",
+    )
+    for uid_dir in users_dir.iterdir():
+        uj = uid_dir / "user.json"
+        if not uj.exists():
+            continue
+        d = _json.loads(uj.read_text())
+        if d.get("email") == "partial@example.com":
+            d["seen_channel_ids"] = ["UC_ALPHA_ID"]
+            uj.write_text(_json.dumps(d))
+            break
+
+    client.post("/login", data={"email": "partial@example.com", "password": "testpassword123"})
+    # /blog renders for this user (they have a subscription); badge should appear
+    r = client.get("/blog")
+    assert b'nav-badge' in r.data
+    assert b'>1<' in r.data
+
+
+def test_nav_badge_hidden_when_seen_channel_ids_absent(logged_in_client, archive):
+    """No badge when seen_channel_ids key is absent (existing-user migration path)."""
+    r = logged_in_client.get("/blog")
+    assert b'nav-badge' not in r.data
+
+
+def test_nav_badge_hidden_after_dashboard_visit(client, archive):
+    """Badge disappears once the user visits /dashboard (marks all as seen)."""
+    import json as _json
+    import web.app as webapp
+
+    # Set up user with only Alpha seen
+    users_dir = webapp.STORAGE_ROOT / "users"
+    _make_user(users_dir, name="Watcher", email="watcher@example.com",
+               channel_ids=["UC_ALPHA_ID"], token="watcher-token")
+    for uid_dir in users_dir.iterdir():
+        uj = uid_dir / "user.json"
+        if not uj.exists():
+            continue
+        d = _json.loads(uj.read_text())
+        if d.get("email") == "watcher@example.com":
+            d["seen_channel_ids"] = ["UC_ALPHA_ID"]
+            uj.write_text(_json.dumps(d))
+            break
+
+    client.post("/login", data={"email": "watcher@example.com", "password": "testpassword123"})
+
+    # Badge present before visiting dashboard (/blog renders since user has a subscription)
+    r = client.get("/blog")
+    assert b'nav-badge' in r.data
+
+    # Visit dashboard — clears the badge
+    client.get("/dashboard")
+
+    # Badge gone on subsequent page load
+    r = client.get("/blog")
+    assert b'nav-badge' not in r.data
+
+
+# ---------------------------------------------------------------------------
 # Security: serve_archive must not expose user data
 # ---------------------------------------------------------------------------
 

--- a/web/app.py
+++ b/web/app.py
@@ -287,12 +287,21 @@ def _prefs_to_classes(prefs: dict) -> str:
 
 @app.context_processor
 def inject_body_classes():
-    """Make body_classes available in every template for the logged-in user."""
+    """Make body_classes and unseen_channel_count available in every template."""
     if current_user.is_authenticated:
         classes = _prefs_to_classes(current_user._data.get("preferences", {}))
+        # Only compute unseen count when seen_channel_ids has been initialised;
+        # absent key means existing user pre-deploy — show nothing to avoid noise.
+        if "seen_channel_ids" in current_user._data:
+            all_ids = {ch["channel_id"] for ch in _load_channels()}
+            seen_ids = set(current_user._data["seen_channel_ids"])
+            unseen_count = len(all_ids - seen_ids)
+        else:
+            unseen_count = 0
     else:
         classes = ""
-    return {"body_classes": classes}
+        unseen_count = 0
+    return {"body_classes": classes, "unseen_channel_count": unseen_count}
 
 
 @app.template_filter("format_ts")
@@ -713,9 +722,14 @@ def dashboard():
             if lines:
                 channel_focus[ch_id] = lines
         current_user._data["channel_focus"] = channel_focus
+        current_user._data["seen_channel_ids"] = [ch["channel_id"] for ch in channels]
         current_user._save()
         flash("Subscriptions updated.", "success")
         return redirect(url_for("dashboard"))
+
+    # GET: mark all channels as seen so the nav badge clears on this page load.
+    current_user._data["seen_channel_ids"] = [ch["channel_id"] for ch in channels]
+    current_user._save()
 
     prefs = current_user._data.get("preferences", {})
     return render_template(
@@ -1219,7 +1233,7 @@ def admin_feed_add():
             if any(ch["channel_id"] == channel_id for ch in channels):
                 flash("A feed with that channel ID already exists.", "error")
             else:
-                channels.append({"channel_id": channel_id, "channel_name": channel_name, "focus": focus})
+                channels.append({"channel_id": channel_id, "channel_name": channel_name, "focus": focus, "added_at": int(time.time())})
                 _save_feeds(channels)
                 flash(f"Feed '{channel_name}' added.", "success")
                 return redirect(url_for("admin_feeds"))

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -123,6 +123,23 @@ nav a:hover { text-decoration: underline; }
 .nav-rss { display: flex; align-items: center; line-height: 0; }
 .nav-rss:hover { opacity: 0.75; }
 
+.nav-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.1rem;
+  height: 1.1rem;
+  padding: 0 0.25rem;
+  border-radius: 999px;
+  background: var(--danger);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  line-height: 1;
+  vertical-align: middle;
+  margin-left: 0.2rem;
+}
+
 /* Main */
 main {
   max-width: var(--max-w);

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -26,7 +26,7 @@
             <path fill="#f26522" d="M1 1a12 12 0 0 1 12 12h-2A10 10 0 0 0 1 3V1z"/>
           </svg>
         </a>
-        <a href="{{ url_for('dashboard') }}">Settings</a>
+        <a href="{{ url_for('dashboard') }}">Settings{% if unseen_channel_count %} <span class="nav-badge">{{ unseen_channel_count }}</span>{% endif %}</a>
         {% if current_user.is_admin %}
           <a href="{{ url_for('admin_user', uid=current_user.get_id()) }}" class="nav-user">{{ current_user.name }}</a>
         {% endif %}


### PR DESCRIPTION
When the admin adds a new channel, users now see a red count badge on the "Settings" nav link until they open the dashboard.

Implementation:
- user.json gains a seen_channel_ids list.  Key absent = not yet initialised (safe migration: existing users see no badge).
- inject_body_classes context processor computes unseen_channel_count (all configured channel IDs minus seen_channel_ids) and injects it into every template.
- GET /dashboard writes seen_channel_ids = all current channel IDs and saves, clearing the badge for that user.  POST /dashboard does the same in the final _save() so the badge is also cleared on a subscriptions save.
- base.html renders <span class="nav-badge"> next to "Settings" when unseen_channel_count > 0.
- .nav-badge CSS: small red pill (var(--danger) background).
- admin_feed_add now stamps added_at on new feed dicts (useful metadata; not used for badge logic which is purely per-user).
- 5 new tests in test_webapp.py covering: GET init, POST init, badge appears, badge absent without key, badge clears after dashboard visit.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk