### PR TITLE
refactor: merge Settings+username nav links; move RSS right; fix iOS …

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -113,12 +113,6 @@ nav a {
 
 nav a:hover { text-decoration: underline; }
 
-.nav-user {
-  font-size: 0.9rem;
-  color: var(--muted);
-  text-decoration: none;
-}
-.nav-user:hover { color: var(--text); text-decoration: underline; }
 
 .nav-rss { display: flex; align-items: center; line-height: 0; }
 .nav-rss:hover { opacity: 0.75; }
@@ -650,7 +644,6 @@ button.btn-danger-sm:hover { background: #fee2e2; }
   border-color: var(--text);
 }
 
-.share-delete-form { display: inline-flex; align-items: stretch; padding: 0; margin: 0; border: none; }
 .share-delete { color: #dc2626; border-color: #fca5a5; }
 .share-delete:hover { color: #fff !important; background: #dc2626 !important; border-color: #dc2626 !important; }
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -19,6 +19,8 @@
         {% endif %}
         <a href="{{ url_for('serve_blog') }}">Blog</a>
         {% block nav_extra %}{% endblock %}
+        <a href="{{ url_for('dashboard') }}">{{ current_user.name }}{% if unseen_channel_count %} <span class="nav-badge">{{ unseen_channel_count }}</span>{% endif %}</a>
+        <a href="{{ url_for('logout') }}">Log out</a>
         <a href="/feed/{{ current_user.feed_token }}.xml" class="nav-rss" title="Subscribe via RSS">
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">
             <circle cx="3" cy="13" r="2" fill="#f26522"/>
@@ -26,11 +28,6 @@
             <path fill="#f26522" d="M1 1a12 12 0 0 1 12 12h-2A10 10 0 0 0 1 3V1z"/>
           </svg>
         </a>
-        <a href="{{ url_for('dashboard') }}">Settings{% if unseen_channel_count %} <span class="nav-badge">{{ unseen_channel_count }}</span>{% endif %}</a>
-        {% if current_user.is_admin %}
-          <a href="{{ url_for('admin_user', uid=current_user.get_id()) }}" class="nav-user">{{ current_user.name }}</a>
-        {% endif %}
-        <a href="{{ url_for('logout') }}">Log out</a>
       {% else %}
         <a href="{{ url_for('login') }}">Log in</a>
         <a href="{{ url_for('register') }}">Create account</a>

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -48,14 +48,11 @@
         <a class="share-email" href="#" title="Share via email">&#128231; Email</a>
         <button type="button" class="share-mastodon" title="Share to Mastodon">&#128024; Mastodon</button>
         {% if current_user.is_authenticated and current_user.is_admin and story.story_filename %}
-        <form method="post" action="{{ url_for('admin_story_delete') }}" class="share-delete-form"
-              data-confirm="Delete &ldquo;{{ story.title | e }}&rdquo;?&#10;This cannot be undone.">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <input type="hidden" name="channel_slug" value="{{ story.channel_slug }}">
-          <input type="hidden" name="meeting_id" value="{{ story.meeting_id }}">
-          <input type="hidden" name="filename" value="{{ story.story_filename }}">
-          <button type="submit" class="share-delete">&#10060; Delete</button>
-        </form>
+        <button type="button" class="share-delete"
+                data-channel="{{ story.channel_slug }}"
+                data-meeting="{{ story.meeting_id }}"
+                data-filename="{{ story.story_filename }}"
+                data-confirm="Delete &ldquo;{{ story.title | e }}&rdquo;?&#10;This cannot be undone.">&#10060; Delete</button>
         {% endif %}
       </div>
     </article>
@@ -151,14 +148,29 @@
                   '_blank', 'noopener,width=600,height=400');
     });
   });
+})();
 
-  document.querySelectorAll('.share-delete-form').forEach(function (form) {
-    form.addEventListener('submit', function (e) {
-      if (!confirm(form.dataset.confirm || 'Delete this story?\nThis cannot be undone.')) {
-        e.preventDefault();
-      }
+{% if current_user.is_authenticated and current_user.is_admin %}
+(function () {
+  var deleteUrl = {{ url_for('admin_story_delete') | tojson }};
+  var csrfToken = {{ csrf_token() | tojson }};
+  document.querySelectorAll('.share-delete').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      if (!confirm(btn.dataset.confirm || 'Delete this story?\nThis cannot be undone.')) return;
+      var fd = new FormData();
+      fd.append('csrf_token', csrfToken);
+      fd.append('channel_slug', btn.dataset.channel);
+      fd.append('meeting_id', btn.dataset.meeting);
+      fd.append('filename', btn.dataset.filename);
+      fetch(deleteUrl, { method: 'POST', body: fd })
+        .then(function (r) {
+          if (r.ok) { window.location.reload(); }
+          else { alert('Delete failed (' + r.status + ').'); }
+        })
+        .catch(function () { alert('Delete failed. Check your connection.'); });
     });
   });
 })();
+{% endif %}
 </script>
 {% endblock %}


### PR DESCRIPTION
…share bar

Nav simplification: the separate admin username link (→ /admin/user/<uid>) and the Settings link (→ /dashboard) pointed to two places for managing one's account. Combined into a single link showing the user's name with the unseen-channel badge, going to /dashboard. The username link and its .nav-user CSS rule are removed. Admins can reach their account detail via the Users admin page as before.

RSS icon moved to far right of the nav bar (past Log out) since it is set-and-forget and doesn't need to be in the main flow.

iOS share bar — definitive fix: the root cause was a <form> element inside the flexbox .story-share container. WebKit/iOS Safari has long-standing bugs with form elements inside flex containers; neither display:contents nor display:inline-flex on the form reliably fixes layout for all iOS Safari versions. The fix is to remove the <form> from the flex container entirely:
- The delete button is now a plain <button type="button"> with data-* attributes (channel, meeting, filename, confirm text).
- A new admin-only JS block uses fetch() + FormData to POST to /admin/story/delete with the CSRF token, then reloads the page on success. No form element inside .story-share at all.
- .share-delete-form CSS rule removed.
- Existing server-side admin_story_delete route unchanged: it still reads from request.form, which Flask populates from both application/x-www-form-urlencoded and multipart/form-data.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk