### PR TITLE
fix: admin name link goes to /admin/user/<uid> (the complete settings…

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -843,6 +843,11 @@ def admin_user(uid: str):
     if not user:
         abort(404)
     channels = sorted(_load_channels(), key=lambda ch: ch.get("channel_name", "").lower())
+    # Clear the unseen-channel nav badge when an admin views their own profile,
+    # since the subscriptions section shows all configured channels.
+    if user.get_id() == current_user.get_id():
+        user._data["seen_channel_ids"] = [ch["channel_id"] for ch in channels]
+        user._save()
     return render_template(
         "admin_user.html",
         u=user,

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -19,7 +19,7 @@
         {% endif %}
         <a href="{{ url_for('serve_blog') }}">Blog</a>
         {% block nav_extra %}{% endblock %}
-        <a href="{{ url_for('dashboard') }}">{{ current_user.name }}{% if unseen_channel_count %} <span class="nav-badge">{{ unseen_channel_count }}</span>{% endif %}</a>
+        <a href="{{ url_for('admin_user', uid=current_user.get_id()) if current_user.is_admin else url_for('dashboard') }}">{{ current_user.name }}{% if unseen_channel_count %} <span class="nav-badge">{{ unseen_channel_count }}</span>{% endif %}</a>
         <a href="{{ url_for('logout') }}">Log out</a>
         <a href="/feed/{{ current_user.feed_token }}.xml" class="nav-rss" title="Subscribe via RSS">
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">


### PR DESCRIPTION
… page)

The previous change pointed the combined username/Settings link to /dashboard for all users. For admins this was wrong: /dashboard has subscriptions and preferences, but lacks name/email editing, password reset, and token rotation. The admin user page (/admin/user/<uid>) already contains all of that plus the full subscriptions+focus+ preferences+feed-URLs sections, making it the natural one-stop settings page for admins.

Change: for admin users the name link in the nav routes to /admin/user/<uid>; for regular users it continues to go to /dashboard. The admin_user() route also clears seen_channel_ids (nav badge) when an admin views their own profile, since the full channel list is visible there just as it is on /dashboard.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk