### PR TITLE
Gracefully handle Supadata quota exhaustion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Defined in `web/app.py`:
 | `_relative_date_to_iso(text)` | Converts a YouTube relative-date string (e.g. `"11 days ago"`) to `YYYY-MM-DD`; parses exact dates from completed-stream text |
 | `_parse_channel_page_metadata(html)` | Extracts `{videoId → {title, date, is_live}}` from the `ytInitialData` JSON blob embedded in a channel listing page |
 | `discover_videos(channel_id)` | Scrapes the channel's `videos` and `streams` tabs; returns `list[VideoInfo]` |
-| `fetch_transcript(video_id, supadata_client)` | Fetches timed transcript segments from Supadata; returns formatted string or None |
+| `fetch_transcript(video_id, supadata_client, ..., transcript_rate_limit_event=None)` | Fetches timed transcript segments from Supadata; returns formatted string or None. When a quota-exhausted error is detected (HTTP 402 or `SupadataError` with a credit-related `error` code), sets `transcript_rate_limit_event` before returning None so callers can stop immediately. |
 
 ### AI story generation
 
@@ -155,8 +155,9 @@ Defined in `web/app.py`:
 
 | Function | Description |
 |---|---|
-| `process_video(video_id, ..., focuses=None)` | Fetch + analyse one video. *focuses* is a list of `(focus_string, user_ids)` pairs; calls Gemini once per pair and writes `**Users:**` metadata for each story. Falls back to `[(feed["focus"], [])]` (unrestricted) when omitted. Deduplicates stories by title across focus passes, merging user_ids. Returns `("content_written", n)`, `("ai_rate_limited", 0)`, or `("skipped", 0)`. |
-| `process_feed(feed, ...)` | Collects focuses via `_collect_channel_focuses`, processes all videos needing work for any focus; returns `(content_changed, ai_rate_limited, stories_written)` |
+| `process_video(video_id, ..., focuses=None, transcript_rate_limit_event=None)` | Fetch + analyse one video. *focuses* is a list of `(focus_string, user_ids)` pairs; calls Gemini once per pair and writes `**Users:**` metadata for each story. Falls back to `[(feed["focus"], [])]` (unrestricted) when omitted. Deduplicates stories by title across focus passes, merging user_ids. Returns `("content_written", n)`, `("ai_rate_limited", 0)`, `("transcript_quota_exhausted", 0)`, or `("skipped", 0)`. Skips the transcript API call immediately if `transcript_rate_limit_event` is already set. |
+| `process_feed(feed, ..., ai_rate_limit_event=None, transcript_rate_limit_event=None)` | Collects focuses via `_collect_channel_focuses`, processes all videos needing work for any focus; returns `(content_changed, ai_rate_limited, stories_written)`. Breaks out of the video loop immediately when `transcript_rate_limit_event` is set. |
+| `_check_supadata_quota(config)` | Reads `archive/supadata_balance.json` (written at the end of the previous run) and returns `(ok, balance)`. If `ok` is False, `_main_body` records `transcript_quota_exhausted: True` in the run log and exits without processing any videos. No live API call is made — uses only the cached file. |
 | `main()` | Entry point: loads config, calls `process_feed` for each configured channel |
 
 ---

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -38,7 +38,7 @@ from typing import TypedDict
 # ---------------------------------------------------------------------------
 import requests
 from feedgen.feed import FeedGenerator
-from supadata import Supadata
+from supadata import Supadata, SupadataError
 
 # ---------------------------------------------------------------------------
 # Environment & paths
@@ -477,11 +477,17 @@ def fetch_transcript(
     supadata_client: Supadata,
     feed_name: str = "",
     video_title: str = "",
+    transcript_rate_limit_event: threading.Event | None = None,
 ) -> str | None:
     """Fetch timed transcript segments from the Supadata API.
 
     Each segment is formatted as ``"<offset_seconds>s --> <text>"`` so Gemini
     knows where each sentence occurs in the video timeline.
+
+    When a quota-exhausted error is detected (HTTP 402 or a
+    ``SupadataError`` whose ``error`` code suggests credit exhaustion),
+    *transcript_rate_limit_event* is set so that ``process_video`` and
+    ``process_feed`` can abort remaining videos immediately.
 
     Returns the formatted transcript string, or None if the API call fails.
     """
@@ -500,7 +506,26 @@ def fetch_transcript(
             logger.debug(f"{prefix}Supadata: Received {len(segments)} segments")
             return "\n".join(lines)
     except Exception as exc:
-        if "live streaming" in str(exc).lower():
+        exc_str = str(exc).lower()
+        # Detect quota / credit exhaustion from SupadataError or HTTP 402/429.
+        is_quota_error = False
+        if isinstance(exc, SupadataError):
+            is_quota_error = any(
+                kw in (exc.error or "").lower()
+                for kw in ("credit", "quota", "payment", "limit", "billing")
+            )
+        elif isinstance(exc, requests.exceptions.HTTPError):
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            is_quota_error = status == 402
+
+        if is_quota_error:
+            logger.error(
+                f"{prefix}Supadata: Quota exhausted — no credits remaining. "
+                f"Halting transcript fetches for this run."
+            )
+            if transcript_rate_limit_event is not None:
+                transcript_rate_limit_event.set()
+        elif "live streaming" in exc_str:
             logger.warning(f"{prefix}Supadata: Live stream — transcript unavailable, will retry next run")
         else:
             logger.error(f"{prefix}Supadata: Call failed: {exc}")
@@ -1163,6 +1188,7 @@ def process_video(
     video_num: int = 0,
     total_videos: int = 0,
     focuses: list[tuple[str, list[str]]] | None = None,
+    transcript_rate_limit_event: threading.Event | None = None,
 ) -> str:
     """Fetch, analyse, and archive one video.
 
@@ -1178,17 +1204,24 @@ def process_video(
 
     Returns a ``(status, n_stories)`` tuple where *status* is one of:
 
-        ``"content_written"``  – stories were generated and written to disk;
-                                 *n_stories* is the count of new stories added.
-        ``"ai_rate_limited"``  – Gemini returned 429; caller should set
-                                 ``ai_disabled = True`` for the session;
-                                 *n_stories* is 0.
-        ``"skipped"``          – transcript unavailable, live stream, AI
-                                 disabled, or AI returned nothing; *n_stories*
-                                 is 0.  When Gemini returns an empty story list,
-                                 a ``metadata.json`` with ``status: "no_stories"``
-                                 is written so the video is not resubmitted to
-                                 the AI on future runs.
+        ``"content_written"``         – stories were generated and written to
+                                        disk; *n_stories* is the count of new
+                                        stories added.
+        ``"ai_rate_limited"``         – Gemini returned 429; caller should set
+                                        ``ai_disabled = True`` for the session;
+                                        *n_stories* is 0.
+        ``"transcript_quota_exhausted"`` – Supadata quota is exhausted;
+                                        *transcript_rate_limit_event* has been
+                                        set; caller should stop processing
+                                        further videos; *n_stories* is 0.
+        ``"skipped"``                 – transcript unavailable, live stream, AI
+                                        disabled, or AI returned nothing;
+                                        *n_stories* is 0.  When Gemini returns
+                                        an empty story list, a
+                                        ``metadata.json`` with
+                                        ``status: "no_stories"`` is written so
+                                        the video is not resubmitted to the AI
+                                        on future runs.
     """
     if focuses is None:
         focuses = [(feed.get("focus", ""), [])]
@@ -1209,6 +1242,9 @@ def process_video(
         video_date = existing_dir.name.split("_")[0]
         meeting_dir = existing_dir
     else:
+        # If quota was already known exhausted, don't attempt the API call.
+        if transcript_rate_limit_event is not None and transcript_rate_limit_event.is_set():
+            return "transcript_quota_exhausted", 0
         counter = f" ({video_num}/{total_videos})" if total_videos else ""
         logger.info(f"{channel_name}: {video_title}: TubeNews: Processing new video{counter}")
         if is_live:
@@ -1218,8 +1254,12 @@ def process_video(
         transcript_text = fetch_transcript(
             video_id, supadata_client,
             feed_name=channel_name, video_title=video_title,
+            transcript_rate_limit_event=transcript_rate_limit_event,
         )
         if not transcript_text:
+            # Distinguish quota exhaustion from ordinary fetch failure.
+            if transcript_rate_limit_event is not None and transcript_rate_limit_event.is_set():
+                return "transcript_quota_exhausted", 0
             return "skipped", 0
 
         meeting_dir = feed_dir / f"{video_date}_{video_id}"
@@ -1293,6 +1333,7 @@ def process_feed(
     supadata_client: Supadata,
     config: dict,
     ai_rate_limit_event: threading.Event | None = None,
+    transcript_rate_limit_event: threading.Event | None = None,
 ) -> tuple[bool, bool, int]:
     """Process all new videos for one configured channel.
 
@@ -1302,6 +1343,10 @@ def process_feed(
     *ai_rate_limit_event* is an optional shared :class:`threading.Event`.
     When set (by any channel hitting a 429), all channels skip further AI
     calls for the remainder of the run.  Pass ``None`` for single-channel use.
+
+    *transcript_rate_limit_event* is an optional shared :class:`threading.Event`.
+    When set (Supadata quota exhausted), processing stops immediately for all
+    remaining videos across all channels.
 
     Returns:
         A ``(content_changed, ai_rate_limited, stories_written)`` tuple.
@@ -1402,6 +1447,7 @@ def process_feed(
             video_num=video_num,
             total_videos=total,
             focuses=focuses,
+            transcript_rate_limit_event=transcript_rate_limit_event,
         )
 
         if result == "content_written":
@@ -1411,6 +1457,9 @@ def process_feed(
             ai_rate_limited = True
             if ai_rate_limit_event is not None:
                 ai_rate_limit_event.set()
+        elif result == "transcript_quota_exhausted":
+            # Event already set by process_video; stop wasting time on this feed.
+            break
 
     return content_changed, ai_rate_limited, stories_written
 
@@ -1504,13 +1553,38 @@ def _main_body(args) -> None:
     supadata_client = Supadata(api_key=config["supadata_api_key"])
     logger.info(f"Session Start | {_fmt_no_leading_zeros(datetime.now(), '%A, %B %d, %Y')} | AI Model: {config.get('gemini_model')}")
 
+    # Check cached Supadata balance before doing any work.
+    quota_ok, cached_balance = _check_supadata_quota(config)
+    started_at = time.time()
+    if not quota_ok:
+        run_log_path = STORAGE_ROOT / "run_log.json"
+        try:
+            runs = json.loads(run_log_path.read_text()) if run_log_path.exists() else []
+        except Exception:
+            runs = []
+        runs.append({
+            "started_at": started_at,
+            "finished_at": time.time(),
+            "total_stories": 0,
+            "ai_rate_limited": False,
+            "transcript_quota_exhausted": True,
+            "feeds": [],
+        })
+        try:
+            run_log_path.write_text(json.dumps(runs[-30:], indent=2))
+        except Exception as exc:
+            logger.warning(f"TubeNews: Failed to write run log: {exc}")
+        return
+
     ai_rate_limit_event = threading.Event()
+    transcript_rate_limit_event = threading.Event()
     any_content_changed = threading.Event()
 
     def _run_feed(feed: FeedConfig) -> FeedResult:
         try:
             content_changed, _, stories_written = process_feed(
-                feed, supadata_client, config, ai_rate_limit_event
+                feed, supadata_client, config, ai_rate_limit_event,
+                transcript_rate_limit_event,
             )
             if content_changed:
                 rebuild_feed(STORAGE_ROOT / slugify(feed["channel_name"]), feed)
@@ -1531,7 +1605,6 @@ def _main_body(args) -> None:
                 "stories_written": 0,
             }
 
-    started_at = time.time()
     max_workers = min(len(config["feeds"]), config.get("max_parallel_feeds", 3))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         feed_results = list(executor.map(_run_feed, config["feeds"]))
@@ -1567,6 +1640,7 @@ def _main_body(args) -> None:
         "finished_at": time.time(),
         "total_stories": total_stories,
         "ai_rate_limited": ai_rate_limit_event.is_set(),
+        "transcript_quota_exhausted": transcript_rate_limit_event.is_set(),
         "feeds": feed_results,
     })
     try:
@@ -1579,6 +1653,47 @@ def _main_body(args) -> None:
         _send_ntfy(ntfy_topic, total_stories, feed_results, started_at)
 
     _cache_supadata_balance(config)
+
+
+def _check_supadata_quota(config: dict) -> tuple[bool, dict | None]:
+    """Check Supadata credit balance before starting a run.
+
+    Reads the balance cached at the end of the previous run
+    (``archive/supadata_balance.json``) — no live API call is made here so no
+    credits are consumed.  If the file is absent (first run) we proceed
+    optimistically; the end-of-run cache will populate it for next time.
+
+    Returns:
+        ``(ok, balance)`` — *ok* is True when there are credits remaining
+        (or when the balance cannot be determined), *balance* is the raw
+        cached dict or None.  When *ok* is False the caller should abort
+        and record ``transcript_quota_exhausted`` in the run log.
+    """
+    balance_path = STORAGE_ROOT / "supadata_balance.json"
+    if not balance_path.exists():
+        return True, None
+    try:
+        balance = json.loads(balance_path.read_text())
+    except Exception:
+        return True, None
+    max_credits = balance.get("maxCredits", 0)
+    used_credits = balance.get("usedCredits", 0)
+    remaining = max_credits - used_credits
+    if max_credits > 0 and remaining <= 0:
+        reset_date = balance.get("resetDate", "unknown")
+        logger.error(
+            f"TubeNews: Supadata quota exhausted (0 of {max_credits} credits remaining). "
+            f"Resets: {reset_date}. Aborting run — no transcripts can be fetched."
+        )
+        return False, balance
+    if max_credits > 0:
+        pct_used = used_credits / max_credits * 100
+        if pct_used >= 90:
+            logger.warning(
+                f"TubeNews: Supadata credits low — {remaining} of {max_credits} remaining "
+                f"({pct_used:.0f}% used)."
+            )
+    return True, balance
 
 
 def _cache_supadata_balance(config: dict) -> None:

--- a/tests/test_tubenews.py
+++ b/tests/test_tubenews.py
@@ -29,6 +29,8 @@ from TubeNews import (
     _acquire_lock,
     _release_lock,
     _story_matches_focus,
+    _check_supadata_quota,
+    fetch_transcript,
 )
 
 
@@ -1602,3 +1604,151 @@ def test_rebuild_user_blog_skips_corrupt_story_file(tmp_path, monkeypatch):
 
     html = (tmp_path / "users" / "Alice" / "index.html").read_text()
     assert "Story 1 from Alpha City Council" in html
+
+
+# ---------------------------------------------------------------------------
+# Supadata quota handling
+# ---------------------------------------------------------------------------
+
+def test_check_supadata_quota_no_file_proceeds(tmp_path, monkeypatch):
+    """When no cached balance file exists, quota check returns ok=True."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+    ok, balance = _check_supadata_quota({"supadata_api_key": "key"})
+    assert ok is True
+    assert balance is None
+
+
+def test_check_supadata_quota_credits_remaining(tmp_path, monkeypatch):
+    """When credits are available, quota check returns ok=True."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+    (tmp_path / "supadata_balance.json").write_text(json.dumps({
+        "maxCredits": 1000, "usedCredits": 500, "plan": "starter",
+    }))
+    ok, balance = _check_supadata_quota({"supadata_api_key": "key"})
+    assert ok is True
+    assert balance["usedCredits"] == 500
+
+
+def test_check_supadata_quota_exhausted(tmp_path, monkeypatch):
+    """When usedCredits == maxCredits, quota check returns ok=False."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+    (tmp_path / "supadata_balance.json").write_text(json.dumps({
+        "maxCredits": 1000, "usedCredits": 1000, "plan": "starter",
+        "resetDate": "2026-04-01",
+    }))
+    ok, balance = _check_supadata_quota({"supadata_api_key": "key"})
+    assert ok is False
+    assert balance["resetDate"] == "2026-04-01"
+
+
+def test_check_supadata_quota_over_limit(tmp_path, monkeypatch):
+    """When usedCredits exceeds maxCredits, quota check returns ok=False."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+    (tmp_path / "supadata_balance.json").write_text(json.dumps({
+        "maxCredits": 1000, "usedCredits": 1001, "plan": "starter",
+    }))
+    ok, _ = _check_supadata_quota({"supadata_api_key": "key"})
+    assert ok is False
+
+
+def test_check_supadata_quota_corrupt_file_proceeds(tmp_path, monkeypatch):
+    """A corrupt balance file is treated as 'unknown' — proceed optimistically."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+    (tmp_path / "supadata_balance.json").write_bytes(b"\xff\xfe not json")
+    ok, balance = _check_supadata_quota({"supadata_api_key": "key"})
+    assert ok is True
+    assert balance is None
+
+
+def test_fetch_transcript_sets_quota_event_on_supadata_error(monkeypatch):
+    """fetch_transcript sets transcript_rate_limit_event when SupadataError has a credit error code."""
+    import threading
+    import TubeNews
+    from supadata import SupadataError
+
+    mock_client = type("C", (), {
+        "transcript": staticmethod(lambda **kw: (_ for _ in ()).throw(
+            SupadataError(error="insufficient-credits", message="No credits", details="")
+        ))
+    })()
+
+    event = threading.Event()
+    result = fetch_transcript("VID123", mock_client, transcript_rate_limit_event=event)
+    assert result is None
+    assert event.is_set()
+
+
+def test_fetch_transcript_sets_quota_event_on_http_402(monkeypatch):
+    """fetch_transcript sets transcript_rate_limit_event on HTTP 402 HTTPError."""
+    import threading
+    import requests as _requests
+    from unittest.mock import MagicMock
+
+    mock_response = MagicMock()
+    mock_response.status_code = 402
+    http_err = _requests.exceptions.HTTPError(response=mock_response)
+
+    mock_client = type("C", (), {
+        "transcript": staticmethod(lambda **kw: (_ for _ in ()).throw(http_err))
+    })()
+
+    event = threading.Event()
+    result = fetch_transcript("VID123", mock_client, transcript_rate_limit_event=event)
+    assert result is None
+    assert event.is_set()
+
+
+def test_fetch_transcript_does_not_set_event_on_other_errors(monkeypatch):
+    """fetch_transcript does NOT set the event for non-quota errors (e.g. video not found)."""
+    import threading
+    from supadata import SupadataError
+
+    mock_client = type("C", (), {
+        "transcript": staticmethod(lambda **kw: (_ for _ in ()).throw(
+            SupadataError(error="video-not-found", message="Not found", details="")
+        ))
+    })()
+
+    event = threading.Event()
+    result = fetch_transcript("VID123", mock_client, transcript_rate_limit_event=event)
+    assert result is None
+    assert not event.is_set()
+
+
+def test_process_feed_stops_on_transcript_quota_exhausted(tmp_path, monkeypatch):
+    """process_feed must stop processing further videos once transcript quota is exhausted."""
+    import threading
+    import TubeNews
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+
+    yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: [
+        {"id": "VID_A", "title": "Meeting A", "date": yesterday, "is_live": False},
+        {"id": "VID_B", "title": "Meeting B", "date": yesterday, "is_live": False},
+    ])
+
+    calls = []
+
+    def fake_fetch(video_id, client, feed_name="", video_title="",
+                   transcript_rate_limit_event=None):
+        calls.append(video_id)
+        if transcript_rate_limit_event is not None:
+            transcript_rate_limit_event.set()
+        return None
+
+    monkeypatch.setattr(TubeNews, "fetch_transcript", fake_fetch)
+
+    from unittest.mock import MagicMock
+    feed = {"channel_id": "UCtest1234567890", "channel_name": "Test Channel", "focus": "test"}
+    event = threading.Event()
+    process_feed(feed, MagicMock(), {"gemini_api_key": "k", "gemini_model": "m"},
+                 transcript_rate_limit_event=event)
+
+    # Only one video should have been attempted before the event stopped the loop.
+    assert len(calls) == 1
+    assert event.is_set()

--- a/web/app.py
+++ b/web/app.py
@@ -1181,6 +1181,7 @@ def admin_runs():
         channel_stats=_archive_channel_stats(),
         is_running=is_running,
         starting=starting,
+        supadata=_get_supadata_balance(),
     )
 
 

--- a/web/templates/admin_runs.html
+++ b/web/templates/admin_runs.html
@@ -35,6 +35,20 @@
     {% endif %}
   </div>
 
+  {% if supadata %}
+    {% set remaining = supadata.maxCredits - supadata.usedCredits %}
+    {% if remaining <= 0 %}
+      <div style="background:var(--danger-bg, #fff0f0); border:1px solid var(--danger, #c00); border-radius:6px; padding:0.75rem 1rem; margin-bottom:1.25rem; font-size:0.9rem;">
+        <strong>Supadata quota exhausted.</strong>
+        No transcript credits remaining ({{ supadata.usedCredits | int }} / {{ supadata.maxCredits | int }} used).
+        Runs are aborted until quota resets.
+        {% if supadata.resetDate %}
+          Resets: <strong>{{ supadata.resetDate }}</strong>.
+        {% endif %}
+      </div>
+    {% endif %}
+  {% endif %}
+
   {% if runs %}
   <table class="user-table" id="runs-table">
     <thead>
@@ -43,6 +57,7 @@
         <th>Duration</th>
         <th>Stories</th>
         <th>AI</th>
+        <th>Transcripts</th>
         <th>Channels</th>
       </tr>
     </thead>
@@ -61,6 +76,13 @@
           {% endif %}
         </td>
         <td>
+          {% if run.transcript_quota_exhausted %}
+            <span class="pill pill-locked">Quota exhausted</span>
+          {% else %}
+            <span class="pill pill-active">OK</span>
+          {% endif %}
+        </td>
+        <td>
           {% set active = run.feeds | selectattr("stories_written", "gt", 0) | list %}
           {% if active %}
             {% for f in active %}
@@ -72,7 +94,7 @@
         </td>
       </tr>
       <tr class="run-detail" id="run-detail-{{ rid }}" style="display:none;">
-        <td colspan="5" style="padding:0 1rem 0.75rem 2.5rem; background:var(--bg);">
+        <td colspan="6" style="padding:0 1rem 0.75rem 2.5rem; background:var(--bg);">
           <table style="font-size:0.85rem; border-collapse:collapse; width:100%;">
             <thead>
               <tr>


### PR DESCRIPTION
- Check cached supadata_balance.json at startup; abort run immediately with transcript_quota_exhausted flag in run_log if 0 credits remain. No live API call is made at startup so no credits are consumed.
- Warn in logs when credits fall below 10%.
- fetch_transcript() detects quota-exhausted responses (HTTP 402 or SupadataError with credit/quota error code) and sets a shared transcript_rate_limit_event, returning None to its caller.
- process_video() checks the event before calling fetch_transcript and after a None return, propagating "transcript_quota_exhausted" status when detected.
- process_feed() breaks out of the video loop immediately on transcript_quota_exhausted and accepts transcript_rate_limit_event as an optional shared threading.Event.
- _main_body() wires the new event through process_feed and records transcript_quota_exhausted in the run log.
- admin_runs page: new Transcripts column shows OK / Quota exhausted per run; a banner at the top displays when current balance is at zero, including the reset date from the cached balance.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk