### PR TITLE
Add self-service account settings page for non-admin users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,6 +469,10 @@ the web app does **not** call either — the web UI uses dynamic generation only
 | GET | `/logout` | `logout` | Clears session |
 | GET | `/blog` | `serve_blog` | Regenerates and serves the logged-in user's blog |
 | GET | `/channel/<channel_id>` | `channel_blog` | Browse all stories for one channel (no time cutoff); passes `channel_id` to `blog.html` so the sub-header can link to the YouTube channel page |
+| GET/POST | `/account` | `account` | Self-service account settings: change name/email (requires current password) |
+| POST | `/account/password` | `account_password` | Change own password (requires current password; new password min 10 chars) |
+| POST | `/account/rotate-token` | `account_rotate_token` | Issue a new feed token; invalidates old RSS/blog URLs |
+| POST | `/account/delete` | `account_delete` | Delete own account (requires current password + email confirmation) |
 
 **Admin required (`admin_users` in config):**
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1459,3 +1459,206 @@ def test_admin_email_change_updates_index(archive, monkeypatch, admin_client):
     index = _wa._read_email_index()
     assert "old@example.com" not in index
     assert index.get("new@example.com") == uid
+
+
+# ---------------------------------------------------------------------------
+# /account — self-service account settings
+# ---------------------------------------------------------------------------
+
+def test_account_requires_login(client, archive):
+    """GET /account must redirect to login when not authenticated."""
+    r = client.get("/account", follow_redirects=False)
+    assert r.status_code == 302
+    assert "/login" in r.headers["Location"]
+
+
+def test_account_get_returns_200(logged_in_client, archive):
+    """GET /account must return 200 for a logged-in user."""
+    r = logged_in_client.get("/account")
+    assert r.status_code == 200
+    assert b"Account Settings" in r.data
+
+
+def test_account_get_shows_name_and_email(logged_in_client, archive):
+    """Account page must pre-fill the user's current name and email."""
+    r = logged_in_client.get("/account")
+    assert b"Test User" in r.data
+    assert b"test@example.com" in r.data
+
+
+def test_account_info_update_saves_name(logged_in_client, archive):
+    """POST /account with correct password must update display name."""
+    import web.app as _wa
+    r = logged_in_client.post("/account", data={
+        "name": "New Name",
+        "email": "test@example.com",
+        "current_password": "testpassword123",
+    }, follow_redirects=True)
+    assert r.status_code == 200
+    users_dir = _wa.STORAGE_ROOT / "users"
+    for uid_dir in users_dir.iterdir():
+        uj = uid_dir / "user.json"
+        if uj.exists():
+            d = json.loads(uj.read_text())
+            if d.get("email") == "test@example.com":
+                assert d["name"] == "New Name"
+                return
+    pytest.fail("User not found")
+
+
+def test_account_info_wrong_password_rejected(logged_in_client, archive):
+    """POST /account with wrong current password must flash an error and not save."""
+    import web.app as _wa
+    r = logged_in_client.post("/account", data={
+        "name": "Hacked Name",
+        "email": "test@example.com",
+        "current_password": "wrongpassword!",
+    }, follow_redirects=True)
+    assert b"incorrect" in r.data.lower()
+    users_dir = _wa.STORAGE_ROOT / "users"
+    for uid_dir in users_dir.iterdir():
+        uj = uid_dir / "user.json"
+        if uj.exists():
+            d = json.loads(uj.read_text())
+            if d.get("email") == "test@example.com":
+                assert d.get("name") != "Hacked Name"
+                return
+
+
+def test_account_info_email_change_updates_index(logged_in_client, archive, monkeypatch):
+    """Changing email via /account must update the email index."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "users")
+    users_dir = _wa.STORAGE_ROOT / "users"
+    uid = next(
+        p.name for p in users_dir.iterdir()
+        if (p / "user.json").exists() and
+        json.loads((p / "user.json").read_text()).get("email") == "test@example.com"
+    )
+    _wa._index_add("test@example.com", uid)
+
+    logged_in_client.post("/account", data={
+        "name": "Test User",
+        "email": "newemail@example.com",
+        "current_password": "testpassword123",
+    })
+
+    index = _wa._read_email_index()
+    assert "test@example.com" not in index
+    assert index.get("newemail@example.com") == uid
+
+
+def test_account_password_change_succeeds(logged_in_client, archive):
+    """POST /account/password with correct current password must update the hash."""
+    import web.app as _wa
+    from werkzeug.security import check_password_hash as _cph
+    r = logged_in_client.post("/account/password", data={
+        "current_password": "testpassword123",
+        "new_password": "newpassword456",
+    }, follow_redirects=True)
+    assert r.status_code == 200
+    users_dir = _wa.STORAGE_ROOT / "users"
+    for uid_dir in users_dir.iterdir():
+        uj = uid_dir / "user.json"
+        if uj.exists():
+            d = json.loads(uj.read_text())
+            if d.get("email") == "test@example.com":
+                assert _cph(d["password_hash"], "newpassword456")
+                return
+    pytest.fail("User not found")
+
+
+def test_account_password_wrong_current_rejected(logged_in_client, archive):
+    """POST /account/password with wrong current password must flash an error."""
+    r = logged_in_client.post("/account/password", data={
+        "current_password": "wrongpassword!",
+        "new_password": "newpassword456",
+    }, follow_redirects=True)
+    assert b"incorrect" in r.data.lower()
+
+
+def test_account_password_too_short_rejected(logged_in_client, archive):
+    """POST /account/password with a new password under 10 chars must flash an error."""
+    r = logged_in_client.post("/account/password", data={
+        "current_password": "testpassword123",
+        "new_password": "short",
+    }, follow_redirects=True)
+    assert b"10 char" in r.data.lower() or b"least 10" in r.data.lower()
+
+
+def test_account_rotate_token_issues_new_token(logged_in_client, archive):
+    """POST /account/rotate-token must change the user's feed_token."""
+    import web.app as _wa
+    old_token = "known-test-feed-token-abc123"
+    logged_in_client.post("/account/rotate-token")
+    users_dir = _wa.STORAGE_ROOT / "users"
+    for uid_dir in users_dir.iterdir():
+        uj = uid_dir / "user.json"
+        if uj.exists():
+            d = json.loads(uj.read_text())
+            if d.get("email") == "test@example.com":
+                assert d["feed_token"] != old_token
+                return
+    pytest.fail("User not found")
+
+
+def test_account_delete_requires_login(client, archive):
+    """POST /account/delete must redirect to login when not authenticated."""
+    r = client.post("/account/delete", data={
+        "current_password": "testpassword123",
+        "confirm_email": "test@example.com",
+    }, follow_redirects=False)
+    assert r.status_code == 302
+    assert "/login" in r.headers["Location"]
+
+
+def test_account_delete_wrong_password_rejected(logged_in_client, archive):
+    """POST /account/delete with wrong password must flash an error and not delete."""
+    import web.app as _wa
+    r = logged_in_client.post("/account/delete", data={
+        "current_password": "wrongpassword!",
+        "confirm_email": "test@example.com",
+    }, follow_redirects=True)
+    assert b"incorrect" in r.data.lower()
+    users_dir = _wa.STORAGE_ROOT / "users"
+    emails = [
+        json.loads((p / "user.json").read_text()).get("email")
+        for p in users_dir.iterdir()
+        if (p / "user.json").exists()
+    ]
+    assert "test@example.com" in emails
+
+
+def test_account_delete_wrong_email_confirmation_rejected(logged_in_client, archive):
+    """POST /account/delete with wrong email confirmation must not delete the account."""
+    import web.app as _wa
+    r = logged_in_client.post("/account/delete", data={
+        "current_password": "testpassword123",
+        "confirm_email": "wrong@example.com",
+    }, follow_redirects=True)
+    assert b"did not match" in r.data.lower() or b"confirmation" in r.data.lower()
+    users_dir = _wa.STORAGE_ROOT / "users"
+    emails = [
+        json.loads((p / "user.json").read_text()).get("email")
+        for p in users_dir.iterdir()
+        if (p / "user.json").exists()
+    ]
+    assert "test@example.com" in emails
+
+
+def test_account_delete_success_removes_user(logged_in_client, archive, monkeypatch):
+    """POST /account/delete with correct credentials must delete the user directory."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "users")
+    r = logged_in_client.post("/account/delete", data={
+        "current_password": "testpassword123",
+        "confirm_email": "test@example.com",
+    }, follow_redirects=True)
+    assert r.status_code == 200
+    users_dir = _wa.STORAGE_ROOT / "users"
+    emails = [
+        json.loads((p / "user.json").read_text()).get("email")
+        for p in users_dir.iterdir()
+        if (p / "user.json").exists()
+    ]
+    assert "test@example.com" not in emails

--- a/web/app.py
+++ b/web/app.py
@@ -925,6 +925,98 @@ def channel_blog(channel_id: str):
 
 
 # ---------------------------------------------------------------------------
+# Account self-service routes
+# ---------------------------------------------------------------------------
+
+
+@app.route("/account", methods=["GET", "POST"])
+@login_required
+def account():
+    """Self-service account settings: name, email, feed token URLs."""
+    if request.method == "POST":
+        new_name = request.form.get("name", "").strip()
+        new_email = request.form.get("email", "").strip().lower()
+        current_pw = request.form.get("current_password", "")
+        if not new_name or not new_email or "@" not in new_email:
+            flash("Name and a valid email are required.", "error")
+            return redirect(url_for("account"))
+        if not check_password_hash(current_user._data["password_hash"], current_pw):
+            flash("Current password is incorrect.", "error")
+            return redirect(url_for("account"))
+        if new_email != current_user.email:
+            existing = _find_user_by_email(new_email)
+            if existing:
+                flash("That email is already in use by another account.", "error")
+                return redirect(url_for("account"))
+        old_email = current_user.email
+        current_user._data["name"] = new_name
+        current_user._data["email"] = new_email
+        current_user._save()
+        if new_email != old_email:
+            _index_remove(old_email)
+            _index_add(new_email, current_user.get_id())
+        flash("Account info updated.", "success")
+        return redirect(url_for("account"))
+    return render_template(
+        "account.html",
+        feed_url=_feed_url(current_user.feed_token),
+        blog_url=_blog_url(current_user.feed_token),
+    )
+
+
+@app.route("/account/password", methods=["POST"])
+@login_required
+def account_password():
+    """Change the logged-in user's own password."""
+    current_pw = request.form.get("current_password", "")
+    new_pw = request.form.get("new_password", "")
+    if not check_password_hash(current_user._data["password_hash"], current_pw):
+        flash("Current password is incorrect.", "error")
+        return redirect(url_for("account"))
+    if len(new_pw) < 10:
+        flash("New password must be at least 10 characters.", "error")
+        return redirect(url_for("account"))
+    current_user._data["password_hash"] = generate_password_hash(new_pw)
+    current_user._save()
+    flash("Password updated.", "success")
+    return redirect(url_for("account"))
+
+
+@app.route("/account/rotate-token", methods=["POST"])
+@login_required
+def account_rotate_token():
+    """Issue a new feed token for the logged-in user; invalidates old RSS/blog URLs."""
+    current_user._data["feed_token"] = str(uuid.uuid4())
+    current_user._save()
+    flash("Feed token rotated. Your old RSS and blog URLs are now invalid.", "success")
+    return redirect(url_for("account"))
+
+
+@app.route("/account/delete", methods=["POST"])
+@login_required
+def account_delete():
+    """Delete the logged-in user's own account."""
+    current_pw = request.form.get("current_password", "")
+    confirm_email = request.form.get("confirm_email", "").strip().lower()
+    if not check_password_hash(current_user._data["password_hash"], current_pw):
+        flash("Current password is incorrect.", "error")
+        return redirect(url_for("account"))
+    if confirm_email != current_user.email:
+        flash("Email confirmation did not match — account not deleted.", "error")
+        return redirect(url_for("account"))
+    deleted_email = current_user.email
+    uid = current_user.get_id()
+    user_dir = USERS_ROOT / uid
+    logout_user()
+    _index_remove(deleted_email)
+    for f in user_dir.iterdir():
+        f.unlink()
+    user_dir.rmdir()
+    flash("Your account has been deleted.", "success")
+    return redirect(url_for("login"))
+
+
+# ---------------------------------------------------------------------------
 # Admin routes
 # ---------------------------------------------------------------------------
 

--- a/web/templates/account.html
+++ b/web/templates/account.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+{% block title %}Account Settings — TubeNews{% endblock %}
+
+{% block content %}
+<div class="admin">
+  <h1>Account Settings</h1>
+
+  <!-- ── Account info ──────────────────────────────────────────── -->
+  <section class="admin-section">
+    <h2>Account info</h2>
+    <form method="post" action="{{ url_for('account') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="form-row">
+        <label for="name">Display name</label>
+        <input type="text" id="name" name="name" value="{{ current_user.name }}" required>
+      </div>
+      <div class="form-row">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" value="{{ current_user.email }}" required>
+      </div>
+      <div class="form-row">
+        <label for="current_password_info">Current password <span class="hint">(required to save changes)</span></label>
+        <input type="password" id="current_password_info" name="current_password" required autocomplete="current-password">
+      </div>
+      <button type="submit">Save info</button>
+    </form>
+  </section>
+
+  <!-- ── Change password ───────────────────────────────────────── -->
+  <section class="admin-section">
+    <h2>Change password</h2>
+    <form method="post" action="{{ url_for('account_password') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="form-row">
+        <label for="current_password_pw">Current password</label>
+        <input type="password" id="current_password_pw" name="current_password" required autocomplete="current-password">
+      </div>
+      <div class="form-row">
+        <label for="new_password">New password <span class="hint">(min 10 chars)</span></label>
+        <input type="password" id="new_password" name="new_password" minlength="10" required autocomplete="new-password">
+      </div>
+      <button type="submit">Change password</button>
+    </form>
+  </section>
+
+  <!-- ── RSS feed & blog URLs ──────────────────────────────────── -->
+  <section class="admin-section">
+    <h2>RSS feed URL</h2>
+    <div class="feed-url-row">
+      <input type="text" class="feed-url-input" id="feed-url" value="{{ feed_url }}" readonly>
+      <button type="button" onclick="copyUrl('feed-url', this)" class="btn-copy">Copy</button>
+    </div>
+    <h2 style="margin-top:1rem;">Blog URL</h2>
+    <div class="feed-url-row">
+      <input type="text" class="feed-url-input" id="blog-url" value="{{ blog_url }}" readonly>
+      <button type="button" onclick="copyUrl('blog-url', this)" class="btn-copy">Copy</button>
+    </div>
+    <form method="post" action="{{ url_for('account_rotate_token') }}"
+          class="inline-form" onsubmit="return confirm('Rotate the feed token? Your current RSS and blog URLs will stop working.')">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="btn-danger-sm" style="margin-top:0.75rem;">Rotate token</button>
+    </form>
+  </section>
+
+  <!-- ── Delete account ────────────────────────────────────────── -->
+  <section class="admin-section danger-zone">
+    <h2>Delete account</h2>
+    <p class="muted">Permanently removes your account and all generated feed files.
+      Enter your password and type your email address to confirm.</p>
+    <form method="post" action="{{ url_for('account_delete') }}"
+          onsubmit="return confirm('This will permanently delete your account. Are you sure?')">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="form-row">
+        <label for="delete_password">Current password</label>
+        <input type="password" id="delete_password" name="current_password" required autocomplete="current-password">
+      </div>
+      <div class="form-row">
+        <label for="confirm_email">Type <strong>{{ current_user.email }}</strong> to confirm</label>
+        <input type="email" id="confirm_email" name="confirm_email" placeholder="{{ current_user.email }}">
+      </div>
+      <button type="submit" class="btn-danger">Delete my account</button>
+    </form>
+  </section>
+</div>
+
+<script>
+  function copyUrl(inputId, btn) {
+    const input = document.getElementById(inputId);
+    function onCopied() {
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(input.value).then(onCopied).catch(() => fallbackCopy(input, onCopied));
+    } else {
+      fallbackCopy(input, onCopied);
+    }
+  }
+
+  function fallbackCopy(input, onCopied) {
+    input.select();
+    input.setSelectionRange(0, 99999);
+    try {
+      document.execCommand('copy');
+      onCopied();
+    } catch (e) {}
+    window.getSelection().removeAllRanges();
+  }
+</script>
+{% endblock %}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -17,10 +17,12 @@
           <a href="{{ url_for('admin_users') }}">Users</a>
           <a href="{{ url_for('admin_feeds') }}">Feeds</a>
           <a href="{{ url_for('admin_runs') }}">Runs</a>
+        {% else %}
+          <a href="{{ url_for('dashboard') }}">Dashboard{% if unseen_channel_count %} <span class="nav-badge">{{ unseen_channel_count }}</span>{% endif %}</a>
         {% endif %}
         <a href="{{ url_for('serve_blog') }}">Blog</a>
         {% block nav_extra %}{% endblock %}
-        <a href="{{ url_for('admin_user', uid=current_user.get_id()) if current_user.is_admin else url_for('dashboard') }}">{{ current_user.name }}{% if unseen_channel_count %} <span class="nav-badge">{{ unseen_channel_count }}</span>{% endif %}</a>
+        <a href="{{ url_for('admin_user', uid=current_user.get_id()) if current_user.is_admin else url_for('account') }}">{{ current_user.name }}</a>
         <a href="{{ url_for('logout') }}">Log out</a>
         <a href="/feed/{{ current_user.feed_token }}.xml" class="nav-rss" title="Subscribe via RSS">
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">


### PR DESCRIPTION
Regular users had no way to change their name, email, password, rotate their feed token, or delete their own account — those features were admin-only. This adds a /account page (and supporting POST routes) so users can manage their own account without admin help.

Changes:
- web/app.py: add GET/POST /account, POST /account/password, POST /account/rotate-token, POST /account/delete routes; name/email changes require current-password verification; delete requires current password + email confirmation
- web/templates/account.html: new template with four sections — account info, change password, RSS/blog URLs with token rotation, and a danger-zone delete form
- web/templates/base.html: for non-admin users, user's name now links to /account; a new explicit "Dashboard" link is added so subscription management remains accessible
- tests/test_webapp.py: 14 new tests covering all account routes
- CLAUDE.md: route map updated with the four new routes

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk