### PR TITLE
Add inbox/archive read-state feature for blog stories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Defined in `web/app.py`:
 |---|---|---|
 | `ChannelInfo` | `channel_id`, `channel_name` (both `str`) | `_channel_info_for_dir()` return type |
 | `ChannelStat` | `channel_id`, `channel_name`, `processed`, `ignored`, `no_stories`, `story_count` (`int`), `last_processed` (`float`) | `_archive_channel_stats()` return type |
-| `StoryDict` | `title`, `dateline`, `body_html`, `video_id`, `video_title`, `channel_name`, `channel_slug`, `meeting_id`, `story_filename` (`str`), `start_seconds` (`int`), `processed_at` (`float`) | `_get_user_stories()` and `_get_channel_stories()` return type; passed to Flask templates |
+| `StoryDict` | `title`, `dateline`, `body_html`, `video_id`, `video_title`, `channel_name`, `channel_slug`, `meeting_id`, `story_filename` (`str`), `start_seconds` (`int`), `processed_at` (`float`), `content_hash` (`str`) | `_get_user_stories()` and `_get_channel_stories()` return type; passed to Flask templates |
 
 ---
 
@@ -389,7 +389,8 @@ archive/users/
   "feed_token": "550e8400-e29b-41d4-a716-446655440000",
   "created_at": 1741910400,
   "locked": false,
-  "seen_channel_ids": ["UCxxxxxxx", "UCyyyyyyy"]
+  "seen_channel_ids": ["UCxxxxxxx", "UCyyyyyyy"],
+  "read_articles": ["abc123hash", "def456hash"]
 }
 ```
 
@@ -397,6 +398,7 @@ archive/users/
 - `channel_focus` — optional per-channel focus keywords set by the user on the dashboard. Each value is a **list of strings** (one per focus line, up to 3); old installs may store a plain string — both are handled transparently. Missing key or empty list means no filter (show all stories). `_collect_channel_focuses` reads this at processing time to determine which Gemini calls to make for each channel.
 - `feed_token` — UUID generated at registration; authenticates all public (no-login) URLs for that user. Rotating it invalidates both the RSS feed URL and the blog URL simultaneously.
 - `seen_channel_ids` — list of channel IDs the user has "seen" on the dashboard. The `inject_body_classes` context processor diffs this against the current feed list to compute `unseen_channel_count`, which drives the red badge on the "Settings" nav link. Key absent means not yet initialised (pre-feature users); treated as 0 unseen so existing users aren't badged on upgrade. Written (covering all current channels) whenever the user loads or saves the dashboard.
+- `read_articles` — sorted list of `content_hash` strings for articles the user has archived (marked as read). `/blog` (inbox) hides stories whose hash is in this list; `/read` (archive) shows only those stories. Key absent means no articles have been read. Written by the `account_mark_read`, `account_mark_unread`, and `account_mark_all_read` routes.
 
 ### Token Model
 
@@ -471,12 +473,16 @@ the web app does **not** call either — the web UI uses dynamic generation only
 |---|---|---|---|
 | GET/POST | `/dashboard` | `dashboard` | Subscribe to channels; shows feed and blog URLs |
 | GET | `/logout` | `logout` | Clears session |
-| GET | `/blog` | `serve_blog` | Regenerates and serves the logged-in user's blog |
+| GET | `/blog` | `serve_blog` | Serves the logged-in user's unread (inbox) stories |
+| GET | `/read` | `serve_read` | Serves the logged-in user's read (archived) stories |
 | GET | `/channel/<channel_id>` | `channel_blog` | Browse all stories for one channel (no time cutoff); passes `channel_id` to `blog.html` so the sub-header can link to the YouTube channel page |
 | GET/POST | `/account` | `account` | Self-service account settings: change name/email (requires current password) |
 | POST | `/account/password` | `account_password` | Change own password (requires current password; new password min 10 chars) |
 | POST | `/account/rotate-token` | `account_rotate_token` | Issue a new feed token; invalidates old RSS/blog URLs |
 | POST | `/account/delete` | `account_delete` | Delete own account (requires current password + email confirmation) |
+| POST | `/account/mark-read` | `account_mark_read` | Add a `content_hash` to the user's `read_articles`; returns JSON `{"ok": true}` |
+| POST | `/account/mark-unread` | `account_mark_unread` | Remove a `content_hash` from `read_articles`; returns JSON `{"ok": true}` |
+| POST | `/account/mark-all-read` | `account_mark_all_read` | Mark all current stories as read; redirects to `/blog` |
 
 **Admin required (`admin_users` in config):**
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1740,3 +1740,114 @@ def test_account_delete_success_removes_user(logged_in_client, archive, monkeypa
         if (p / "user.json").exists()
     ]
     assert "test@example.com" not in emails
+
+
+# ---------------------------------------------------------------------------
+# Mark read / archive (inbox-zero) tests
+# ---------------------------------------------------------------------------
+
+def test_mark_read_adds_to_read_articles(logged_in_client, archive, monkeypatch):
+    """POST /account/mark-read must persist content_hash in user.json."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "users")
+    r = logged_in_client.post("/account/mark-read", data={"content_hash": "abc123"})
+    assert r.status_code == 200
+    data = json.loads(r.data)
+    assert data["ok"] is True
+    # Find the test user's user.json and verify the hash was saved.
+    users_dir = archive / "users"
+    user_data = None
+    for p in users_dir.iterdir():
+        f = p / "user.json"
+        if f.exists():
+            d = json.loads(f.read_text())
+            if d.get("email") == "test@example.com":
+                user_data = d
+                break
+    assert user_data is not None
+    assert "abc123" in user_data.get("read_articles", [])
+
+
+def test_mark_read_missing_hash_returns_400(logged_in_client, archive):
+    """POST /account/mark-read with no content_hash must return 400."""
+    r = logged_in_client.post("/account/mark-read", data={})
+    assert r.status_code == 400
+
+
+def test_mark_unread_removes_from_read_articles(logged_in_client, archive, monkeypatch):
+    """POST /account/mark-unread must remove content_hash from user.json."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "users")
+    # First mark as read.
+    logged_in_client.post("/account/mark-read", data={"content_hash": "abc123"})
+    # Then mark as unread.
+    r = logged_in_client.post("/account/mark-unread", data={"content_hash": "abc123"})
+    assert r.status_code == 200
+    assert json.loads(r.data)["ok"] is True
+    users_dir = archive / "users"
+    for p in users_dir.iterdir():
+        f = p / "user.json"
+        if f.exists():
+            d = json.loads(f.read_text())
+            if d.get("email") == "test@example.com":
+                assert "abc123" not in d.get("read_articles", [])
+                break
+
+
+def test_mark_unread_missing_hash_returns_400(logged_in_client, archive):
+    """POST /account/mark-unread with no content_hash must return 400."""
+    r = logged_in_client.post("/account/mark-unread", data={})
+    assert r.status_code == 400
+
+
+def test_mark_all_read_redirects_to_blog(logged_in_client, archive, monkeypatch):
+    """POST /account/mark-all-read must redirect to /blog."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    r = logged_in_client.post("/account/mark-all-read")
+    assert r.status_code == 302
+    assert r.headers["Location"].endswith("/blog")
+
+
+def test_serve_read_requires_login(client, archive):
+    """/read must redirect unauthenticated requests to login."""
+    r = client.get("/read")
+    assert r.status_code == 302
+    assert "/login" in r.headers["Location"]
+
+
+def test_serve_read_shows_archived_stories(logged_in_client, archive, monkeypatch):
+    """/read must show only stories whose content_hash is in read_articles."""
+    import hashlib
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    # The story body written by _make_channel is "Story body."
+    # Parse the actual hash so the test doesn't duplicate the hash logic.
+    import TubeNews as _tn
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+    story_file = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    parsed = _tn.parse_story_file(story_file)
+    content_hash = parsed["content_hash"]
+    # Mark that story as read.
+    logged_in_client.post("/account/mark-read", data={"content_hash": content_hash})
+    r = logged_in_client.get("/read")
+    assert r.status_code == 200
+    assert b"Alpha Council Approves Budget" in r.data
+
+
+def test_serve_blog_hides_read_stories(logged_in_client, archive, monkeypatch):
+    """/blog (inbox) must hide stories whose content_hash is in read_articles."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    import TubeNews as _tn
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+    story_file = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    parsed = _tn.parse_story_file(story_file)
+    content_hash = parsed["content_hash"]
+    logged_in_client.post("/account/mark-read", data={"content_hash": content_hash})
+    r = logged_in_client.get("/blog")
+    assert r.status_code == 200
+    assert b"Alpha Council Approves Budget" not in r.data

--- a/web/app.py
+++ b/web/app.py
@@ -28,6 +28,7 @@ from flask import (
     Response,
     abort,
     flash,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -199,6 +200,7 @@ class StoryDict(TypedDict):
     meeting_id: str
     story_filename: str
     processed_at: float
+    content_hash: str
 
 
 # ---------------------------------------------------------------------------
@@ -635,6 +637,7 @@ def _get_user_stories(user_data: dict, user_id: str = "") -> list[StoryDict]:
                 "meeting_id": entry.get("meeting_id", ""),
                 "story_filename": entry["file"].name,
                 "processed_at": entry["meta"].get("processed_at", 0),
+                "content_hash": s.get("content_hash", ""),
             })
         except Exception as exc:
             logger.debug(f"Skipping {entry['file']}: {exc}")
@@ -846,15 +849,33 @@ def serve_blog_public(token: str):
 @app.route("/blog")
 @login_required
 def serve_blog():
-    """Render the logged-in user's blog inside the app template."""
+    """Render the logged-in user's unread (inbox) stories."""
     if not current_user.channel_ids:
         flash("Subscribe to channels to start reading your blog.", "info")
         return redirect(url_for("account"))
-    cfg = _load_config()
-    stories = _get_user_stories(current_user._data, current_user.get_id())
+    read_set = set(current_user._data.get("read_articles", []))
+    all_stories = _get_user_stories(current_user._data, current_user.get_id())
+    stories = [s for s in all_stories if s.get("content_hash", "") not in read_set]
+    read_count = len(all_stories) - len(stories)
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
     return render_template("blog.html", stories=stories, blog_name=blog_name,
-                           feed_path=f"/feed/{current_user.feed_token}.xml")
+                           feed_path=f"/feed/{current_user.feed_token}.xml",
+                           read_count=read_count)
+
+
+@app.route("/read")
+@login_required
+def serve_read():
+    """Render the logged-in user's read (archived) stories."""
+    if not current_user.channel_ids:
+        return redirect(url_for("account"))
+    read_set = set(current_user._data.get("read_articles", []))
+    all_stories = _get_user_stories(current_user._data, current_user.get_id())
+    stories = [s for s in all_stories if s.get("content_hash", "") in read_set]
+    blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
+    return render_template("blog.html", stories=stories, blog_name=blog_name,
+                           feed_path=f"/feed/{current_user.feed_token}.xml",
+                           is_archive=True)
 
 
 @app.route("/channel/<channel_id>")
@@ -1004,6 +1025,49 @@ def account_delete():
     user_dir.rmdir()
     flash("Your account has been deleted.", "success")
     return redirect(url_for("login"))
+
+
+@app.route("/account/mark-read", methods=["POST"])
+@login_required
+def account_mark_read():
+    """Mark a story as read (add content_hash to read_articles). Returns JSON."""
+    content_hash = request.form.get("content_hash", "").strip()
+    if not content_hash:
+        return jsonify({"ok": False, "error": "missing content_hash"}), 400
+    read_set = set(current_user._data.get("read_articles", []))
+    read_set.add(content_hash)
+    current_user._data["read_articles"] = sorted(read_set)
+    current_user._save()
+    return jsonify({"ok": True})
+
+
+@app.route("/account/mark-unread", methods=["POST"])
+@login_required
+def account_mark_unread():
+    """Mark a story as unread (remove content_hash from read_articles). Returns JSON."""
+    content_hash = request.form.get("content_hash", "").strip()
+    if not content_hash:
+        return jsonify({"ok": False, "error": "missing content_hash"}), 400
+    read_set = set(current_user._data.get("read_articles", []))
+    read_set.discard(content_hash)
+    current_user._data["read_articles"] = sorted(read_set)
+    current_user._save()
+    return jsonify({"ok": True})
+
+
+@app.route("/account/mark-all-read", methods=["POST"])
+@login_required
+def account_mark_all_read():
+    """Mark all of the user's current stories as read, then redirect to /blog."""
+    all_stories = _get_user_stories(current_user._data, current_user.get_id())
+    read_set = set(current_user._data.get("read_articles", []))
+    for s in all_stories:
+        h = s.get("content_hash", "")
+        if h:
+            read_set.add(h)
+    current_user._data["read_articles"] = sorted(read_set)
+    current_user._save()
+    return redirect(url_for("serve_blog"))
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -98,6 +98,8 @@ header {
 .header-sub a { color: var(--text); text-decoration: none; }
 .header-sub a:hover { text-decoration: underline; }
 .header-sub .hs-ext { font-weight: 400; font-size: 0.8rem; color: var(--muted); }
+.header-sub .hs-btn { font-weight: 400; font-size: 0.8rem; color: var(--muted); background: none; border: none; cursor: pointer; padding: 0; }
+.header-sub .hs-btn:hover { text-decoration: underline; color: var(--text); }
 
 /* Hamburger toggle — hidden on desktop */
 .nav-toggle {

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -10,13 +10,26 @@
   {% if feed_path %}
   <a class="hs-ext" href="{{ feed_path }}">RSS feed</a>
   {% endif %}
+  {% if current_user.is_authenticated and not channel_id %}
+    {% if is_archive %}
+    <a class="hs-ext" href="{{ url_for('serve_blog') }}">&#8592; Inbox</a>
+    {% else %}
+    <a class="hs-ext" href="{{ url_for('serve_read') }}">Archive{% if read_count %} ({{ read_count }}){% endif %}</a>
+    {% if stories %}
+    <form method="post" action="{{ url_for('account_mark_all_read') }}" style="display:inline">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="hs-btn">Mark all read</button>
+    </form>
+    {% endif %}
+    {% endif %}
+  {% endif %}
 </div>
 {% endblock %}
 
 {% block content %}
 <div class="blog-page">
   <div class="blog-header">
-    <h1>{{ blog_name }}</h1>
+    <h1>{{ blog_name }}{% if is_archive %} &mdash; Archive{% endif %}</h1>
   </div>
 
   {% if stories %}
@@ -40,6 +53,7 @@
            data-dateline="{{ story.dateline | e }}"
            data-anchor="s{{ story.video_id }}-{{ story.start_seconds }}"
            data-youtube="https://youtu.be/{{ story.video_id }}?t={{ story.start_seconds }}"
+           data-content-hash="{{ story.content_hash | e }}"
            {% if story.channel_slug and story.meeting_id %}
            data-transcript="{{ url_for('serve_transcript', channel_slug=story.channel_slug, meeting_id=story.meeting_id) }}#t{{ story.start_seconds }}"
            {% endif %}>
@@ -47,6 +61,13 @@
         <button type="button" class="share-copy-link" title="Copy link to this article">&#128279; Copy link</button>
         <a class="share-email" href="#" title="Share via email">&#128231; Email</a>
         <button type="button" class="share-mastodon" title="Share to Mastodon">&#128024; Mastodon</button>
+        {% if current_user.is_authenticated and not channel_id %}
+          {% if is_archive %}
+          <button type="button" class="share-unread" title="Move back to inbox">&#8592; Move to inbox</button>
+          {% else %}
+          <button type="button" class="share-read" title="Mark as read">&#10003; Mark read</button>
+          {% endif %}
+        {% endif %}
         {% if current_user.is_authenticated and current_user.is_admin and story.story_filename %}
         <button type="button" class="share-delete"
                 data-channel="{{ story.channel_slug }}"
@@ -58,7 +79,11 @@
     </article>
     {% endfor %}
   {% else %}
-    <p class="blog-empty">No stories yet. Check back after the next TubeNews run.</p>
+    {% if is_archive %}
+    <p class="blog-empty">No read articles yet. Mark articles as read from your <a href="{{ url_for('serve_blog') }}">inbox</a>.</p>
+    {% else %}
+    <p class="blog-empty">No unread stories.{% if read_count %} <a href="{{ url_for('serve_read') }}">View {{ read_count }} archived article{% if read_count != 1 %}s{% endif %}</a>.{% else %} Check back after the next TubeNews run.{% endif %}</p>
+    {% endif %}
   {% endif %}
 </div>
 
@@ -168,6 +193,49 @@
     }
   });
 })();
+
+{% if current_user.is_authenticated %}
+(function () {
+  var csrfToken = {{ csrf_token() | tojson }};
+  var markReadUrl   = {{ url_for('account_mark_read')   | tojson }};
+  var markUnreadUrl = {{ url_for('account_mark_unread') | tojson }};
+
+  function postHash(url, hash, btn, article) {
+    var fd = new FormData();
+    fd.append('csrf_token', csrfToken);
+    fd.append('content_hash', hash);
+    fetch(url, { method: 'POST', body: fd })
+      .then(function (r) {
+        if (r.ok) {
+          article.style.transition = 'opacity 0.3s';
+          article.style.opacity = '0';
+          setTimeout(function () { article.remove(); }, 300);
+        } else {
+          alert('Action failed (' + r.status + ').');
+        }
+      })
+      .catch(function () { alert('Action failed. Check your connection.'); });
+  }
+
+  document.querySelectorAll('.share-read').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var bar     = btn.closest('.story-share');
+      var article = btn.closest('article');
+      var hash    = bar.dataset.contentHash;
+      if (hash) postHash(markReadUrl, hash, btn, article);
+    });
+  });
+
+  document.querySelectorAll('.share-unread').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var bar     = btn.closest('.story-share');
+      var article = btn.closest('article');
+      var hash    = bar.dataset.contentHash;
+      if (hash) postHash(markUnreadUrl, hash, btn, article);
+    });
+  });
+})();
+{% endif %}
 
 {% if current_user.is_authenticated and current_user.is_admin %}
 (function () {


### PR DESCRIPTION
The /blog (inbox) view now shows only unread stories. A new /read (archive) view shows articles the user has marked as read. Each story in the inbox has a "Mark read" button that removes it from the inbox via AJAX; the archive view has a "Move to inbox" button. A "Mark all read" form button in the sub-header sweeps everything at once. Read state is stored as a list of content_hash values in user.json under the key read_articles.

New routes: GET /read, POST /account/mark-read, POST /account/mark-unread, POST /account/mark-all-read. StoryDict gains a content_hash field. CLAUDE.md and tests updated accordingly.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk