### PR TITLE
Fix keyboard nav scroll alignment and add Enter to close shortcuts help

### DIFF
--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -330,7 +330,7 @@
       <tr><td>g i</td><td>Go to inbox</td></tr>
       <tr><td>g a</td><td>Go to archive</td></tr>
       <tr><td>?</td><td>Show / hide this help</td></tr>
-      <tr><td>Esc</td><td>Close this help</td></tr>
+      <tr><td>Esc / Enter</td><td>Close this help</td></tr>
     </table>
     <button id="kb-help-close">Close</button>
   </div>
@@ -347,6 +347,21 @@
     return Array.from(document.querySelectorAll('article.story'));
   }
 
+  function stickyHeaderHeight() {
+    var h = 0;
+    document.querySelectorAll('header, .header-sub').forEach(function (el) {
+      var pos = window.getComputedStyle(el).position;
+      if (pos === 'sticky' || pos === 'fixed') h += el.getBoundingClientRect().height;
+    });
+    return h;
+  }
+
+  function scrollToStory(el) {
+    var offset = stickyHeaderHeight() + 8;
+    var top = window.pageYOffset + el.getBoundingClientRect().top - offset;
+    window.scrollTo({ top: top, behavior: 'smooth' });
+  }
+
   function setFocus(idx) {
     var articles = getArticles();
     if (!articles.length) return;
@@ -356,7 +371,7 @@
     var el = articles[focusIdx];
     if (el) {
       el.classList.add('story-focused');
-      el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      scrollToStory(el);
     }
   }
 
@@ -376,7 +391,7 @@
 
     var key = e.key;
 
-    if (key === 'Escape') { hideHelp(); return; }
+    if (key === 'Escape' || (key === 'Enter' && helpEl.style.display === 'flex')) { hideHelp(); return; }
     if (key === '?') { e.preventDefault(); helpEl.style.display === 'flex' ? hideHelp() : showHelp(); return; }
 
     if (pendingG) {


### PR DESCRIPTION
- Replace scrollIntoView(nearest) with a custom scroll function that positions the selected article just below the sticky headers (main header + sub-header), so j/k/e/u never leave fragments of the previous story visible at the top or cut off the article title.
- Enter now closes the keyboard-shortcuts dialog (same as Escape), so the user can open ? and dismiss with keyboard alone.
- Update the shortcuts table to show "Esc / Enter" for close.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk