### PR TITLE
Redesign sub-header bar into three-section layout for news feed

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -91,15 +91,46 @@ header {
   height: 36px;
   display: flex;
   align-items: center;
-  gap: 1rem;
-  font-size: 0.9rem;
-  font-weight: 600;
+  justify-content: space-between;
+  font-size: 0.85rem;
 }
 .header-sub a { color: var(--text); text-decoration: none; }
 .header-sub a:hover { text-decoration: underline; }
-.header-sub .hs-ext { font-weight: 400; font-size: 0.8rem; color: var(--muted); }
-.header-sub .hs-btn { font-weight: 400; font-size: 0.8rem; color: var(--muted); background: none; border: none; cursor: pointer; padding: 0; }
-.header-sub .hs-btn:hover { text-decoration: underline; color: var(--text); }
+/* Left: feed name + nav tabs */
+.hs-left { flex: 1; display: flex; align-items: center; gap: 0.75rem; min-width: 0; }
+.hs-feed-name { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hs-tab { font-weight: 400; color: var(--muted); padding: 0 0.1rem; border-bottom: 2px solid transparent; line-height: 36px; }
+.hs-tab:hover { color: var(--text); text-decoration: none; }
+.hs-tab-active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 500; }
+/* Center: action buttons */
+.hs-center { display: flex; align-items: center; justify-content: center; gap: 0.5rem; }
+.hs-action-btn {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  padding: 0.2rem 0.65rem;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.hs-action-btn:hover { background: var(--border); }
+/* Right: RSS and external links */
+.hs-right { flex: 1; display: flex; align-items: center; justify-content: flex-end; gap: 0.75rem; }
+.hs-ext { font-weight: 400; font-size: 0.8rem; color: var(--muted); }
+.hs-ext:hover { color: var(--text); }
+.hs-rss {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.1rem 0.45rem;
+  white-space: nowrap;
+}
+.hs-rss:hover { color: var(--text); border-color: var(--text); text-decoration: none; }
 
 /* Hamburger toggle — hidden on desktop */
 .nav-toggle {

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -3,26 +3,32 @@
 
 {% block header_sub %}
 <div class="header-sub">
-  <span>{{ blog_name }}</span>
-  {% if channel_id %}
-  <a class="hs-ext" href="https://www.youtube.com/channel/{{ channel_id }}" target="_blank" rel="noopener">&#9654; YouTube channel</a>
-  {% endif %}
-  {% if feed_path %}
-  <a class="hs-ext" href="{{ feed_path }}">RSS feed</a>
-  {% endif %}
-  {% if current_user.is_authenticated and not channel_id %}
-    {% if is_archive %}
-    <a class="hs-ext" href="{{ url_for('serve_blog') }}">&#8592; Inbox</a>
-    {% else %}
-    <a class="hs-ext" href="{{ url_for('serve_read') }}">Archive{% if read_count %} ({{ read_count }}){% endif %}</a>
-    {% if stories %}
+  <div class="hs-left">
+    <span class="hs-feed-name">{{ blog_name }}</span>
+    {% if current_user.is_authenticated %}
+      <a class="hs-tab{% if not is_archive and not channel_id %} hs-tab-active{% endif %}" href="{{ url_for('serve_blog') }}">Unread</a>
+      <a class="hs-tab{% if is_archive %} hs-tab-active{% endif %}" href="{{ url_for('serve_read') }}">Archive</a>
+      {% if channel_id %}
+      <span class="hs-tab hs-tab-active">All</span>
+      {% endif %}
+    {% endif %}
+  </div>
+  <div class="hs-center">
+    {% if current_user.is_authenticated and not channel_id and not is_archive and stories %}
     <form method="post" action="{{ url_for('account_mark_all_read') }}" style="display:inline">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <button type="submit" class="hs-btn">Mark all read</button>
+      <button type="submit" class="hs-action-btn">Mark all read</button>
     </form>
     {% endif %}
+  </div>
+  <div class="hs-right">
+    {% if channel_id %}
+    <a class="hs-ext" href="https://www.youtube.com/channel/{{ channel_id }}" target="_blank" rel="noopener">&#9654; YouTube</a>
     {% endif %}
-  {% endif %}
+    {% if feed_path %}
+    <a class="hs-rss" href="{{ feed_path }}">RSS</a>
+    {% endif %}
+  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Left: feed name + Unread/Archive nav tabs (All added on channel pages).
Center: Mark all read action styled as a bordered button.
Right: RSS link styled as a pill badge.

Active tab highlighted with accent-color underline. YouTube channel link shortened to "▶ YouTube" to keep the right section compact.

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk