### PR TITLE
Add /all view and fix sub-header tab layout for blog pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,6 +475,7 @@ the web app does **not** call either — the web UI uses dynamic generation only
 | GET | `/logout` | `logout` | Clears session |
 | GET | `/blog` | `serve_blog` | Serves the logged-in user's unread (inbox) stories |
 | GET | `/read` | `serve_read` | Serves the logged-in user's read (archived) stories |
+| GET | `/all` | `serve_all` | Serves all of the logged-in user's stories regardless of read status |
 | GET | `/channel/<channel_id>` | `channel_blog` | Browse all stories for one channel (no time cutoff); passes `channel_id` to `blog.html` so the sub-header can link to the YouTube channel page |
 | GET/POST | `/account` | `account` | Self-service account settings: change name/email (requires current password) |
 | POST | `/account/password` | `account_password` | Change own password (requires current password; new password min 10 chars) |

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1851,3 +1851,37 @@ def test_serve_blog_hides_read_stories(logged_in_client, archive, monkeypatch):
     r = logged_in_client.get("/blog")
     assert r.status_code == 200
     assert b"Alpha Council Approves Budget" not in r.data
+
+
+# ---------------------------------------------------------------------------
+# /all — combined inbox + archive view
+# ---------------------------------------------------------------------------
+
+
+def test_serve_all_requires_login(client, archive):
+    """/all must redirect unauthenticated requests to login."""
+    r = client.get("/all")
+    assert r.status_code == 302
+    assert "/login" in r.headers["Location"]
+
+
+def test_serve_all_returns_200(logged_in_client):
+    r = logged_in_client.get("/all")
+    assert r.status_code == 200
+
+
+def test_serve_all_shows_both_read_and_unread_stories(logged_in_client, archive, monkeypatch):
+    """/all must show stories regardless of read status."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    import TubeNews as _tn
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+    story_file = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    parsed = _tn.parse_story_file(story_file)
+    content_hash = parsed["content_hash"]
+    # Mark the story as read — /blog would hide it, /all must still show it.
+    logged_in_client.post("/account/mark-read", data={"content_hash": content_hash})
+    r = logged_in_client.get("/all")
+    assert r.status_code == 200
+    assert b"Alpha Council Approves Budget" in r.data

--- a/web/app.py
+++ b/web/app.py
@@ -878,6 +878,19 @@ def serve_read():
                            is_archive=True)
 
 
+@app.route("/all")
+@login_required
+def serve_all():
+    """Render all of the logged-in user's stories regardless of read status."""
+    if not current_user.channel_ids:
+        return redirect(url_for("account"))
+    stories = _get_user_stories(current_user._data, current_user.get_id())
+    blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
+    return render_template("blog.html", stories=stories, blog_name=blog_name,
+                           feed_path=f"/feed/{current_user.feed_token}.xml",
+                           is_all=True)
+
+
 @app.route("/channel/<channel_id>")
 @login_required
 def channel_blog(channel_id: str):

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -102,21 +102,6 @@ header {
 .hs-tab { font-weight: 400; color: var(--muted); padding: 0 0.1rem; border-bottom: 2px solid transparent; line-height: 36px; }
 .hs-tab:hover { color: var(--text); text-decoration: none; }
 .hs-tab-active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 500; }
-/* Center: action buttons */
-.hs-center { display: flex; align-items: center; justify-content: center; gap: 0.5rem; }
-.hs-action-btn {
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--text);
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  cursor: pointer;
-  padding: 0.2rem 0.65rem;
-  line-height: 1.4;
-  white-space: nowrap;
-}
-.hs-action-btn:hover { background: var(--border); }
 /* Right: RSS and external links */
 .hs-right { flex: 1; display: flex; align-items: center; justify-content: flex-end; gap: 0.75rem; }
 .hs-ext { font-weight: 400; font-size: 0.8rem; color: var(--muted); }
@@ -589,6 +574,26 @@ button.btn-danger-sm {
 button.btn-danger-sm:hover { background: #fee2e2; }
 
 /* ── Blog page ───────────────────────────────────────────────── */
+
+.blog-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.5rem 0 0.25rem;
+  margin-bottom: 0.5rem;
+}
+.blog-toolbar-btn {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--muted);
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  padding: 0.2rem 0.65rem;
+  line-height: 1.4;
+}
+.blog-toolbar-btn:hover { color: var(--text); border-color: var(--text); }
 
 .blog-header {
   margin-bottom: 1.75rem;

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -5,20 +5,14 @@
 <div class="header-sub">
   <div class="hs-left">
     <span class="hs-feed-name">{{ blog_name }}</span>
-    {% if current_user.is_authenticated %}
-      <a class="hs-tab{% if not is_archive and not channel_id %} hs-tab-active{% endif %}" href="{{ url_for('serve_blog') }}">Unread</a>
+    {% if current_user.is_authenticated and not channel_id %}
+      <a class="hs-tab{% if not is_archive and not is_all %} hs-tab-active{% endif %}" href="{{ url_for('serve_blog') }}">Unread</a>
       <a class="hs-tab{% if is_archive %} hs-tab-active{% endif %}" href="{{ url_for('serve_read') }}">Archive</a>
-      {% if channel_id %}
+      <a class="hs-tab{% if is_all %} hs-tab-active{% endif %}" href="{{ url_for('serve_all') }}">All</a>
+    {% elif channel_id %}
+      <a class="hs-tab" href="{{ url_for('serve_blog') }}">Unread</a>
+      <a class="hs-tab" href="{{ url_for('serve_read') }}">Archive</a>
       <span class="hs-tab hs-tab-active">All</span>
-      {% endif %}
-    {% endif %}
-  </div>
-  <div class="hs-center">
-    {% if current_user.is_authenticated and not channel_id and not is_archive and stories %}
-    <form method="post" action="{{ url_for('account_mark_all_read') }}" style="display:inline">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <button type="submit" class="hs-action-btn">Mark all read</button>
-    </form>
     {% endif %}
   </div>
   <div class="hs-right">
@@ -34,9 +28,14 @@
 
 {% block content %}
 <div class="blog-page">
-  <div class="blog-header">
-    <h1>{{ blog_name }}{% if is_archive %} &mdash; Archive{% endif %}</h1>
+  {% if current_user.is_authenticated and not channel_id and not is_archive and not is_all and stories %}
+  <div class="blog-toolbar">
+    <form method="post" action="{{ url_for('account_mark_all_read') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="blog-toolbar-btn">Mark all as read</button>
+    </form>
   </div>
+  {% endif %}
 
   {% if stories %}
     {% for story in stories %}


### PR DESCRIPTION
- Add /all route (serve_all) showing all user stories regardless of read status; always show Unread / Archive / All tabs on personal feed pages with correct active state; channel pages show same three tabs with All active
- Remove Mark all read from sub-header (too tall); move it to a slim toolbar row above the story list on the inbox view
- Remove hs-center / hs-action-btn CSS; add .blog-toolbar styles
- Add three tests for /all (login guard, 200, read+unread both shown)
- Document /all in CLAUDE.md route map

https://claude.ai/code/session_019sig6nh1PFcW786JUgkRUk