### PR TITLE
Fix mark-all buttons: centered in sub-header, match RSS pill style

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -102,6 +102,9 @@ header {
 .hs-tab { font-weight: 400; color: var(--muted); padding: 0 0.1rem; border-bottom: 2px solid transparent; line-height: 36px; }
 .hs-tab:hover { color: var(--text); text-decoration: none; }
 .hs-tab-active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 500; }
+/* Center: bulk action buttons */
+.hs-center { flex: 0 0 auto; display: flex; align-items: center; gap: 0.5rem; }
+.hs-center form { margin: 0; }
 /* Right: RSS and external links */
 .hs-right { flex: 1; display: flex; align-items: center; justify-content: flex-end; gap: 0.75rem; }
 .hs-ext { font-weight: 400; font-size: 0.8rem; color: var(--muted); }
@@ -117,8 +120,11 @@ header {
 }
 .hs-rss:hover { color: var(--text); border-color: var(--text); text-decoration: none; }
 .hs-action-btn {
+  appearance: none;
+  display: inline-block;
   font-size: 0.75rem;
   font-weight: 500;
+  font-family: inherit;
   color: var(--muted);
   background: none;
   border: 1px solid var(--border);
@@ -126,8 +132,9 @@ header {
   cursor: pointer;
   padding: 0.1rem 0.45rem;
   white-space: nowrap;
-  font-family: inherit;
-  line-height: 1.6;
+  line-height: inherit;
+  vertical-align: baseline;
+  margin: 0;
 }
 .hs-action-btn:hover { color: var(--text); border-color: var(--text); }
 

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -15,21 +15,23 @@
       <span class="hs-tab hs-tab-active">All</span>
     {% endif %}
   </div>
-  <div class="hs-right">
+  <div class="hs-center">
     {% if current_user.is_authenticated and not channel_id and stories %}
       {% if not is_archive %}
-      <form method="post" action="{{ url_for('account_mark_all_read') }}" style="display:inline">
+      <form method="post" action="{{ url_for('account_mark_all_read') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="hs-action-btn">Mark all read</button>
       </form>
       {% endif %}
       {% if is_archive or is_all %}
-      <form method="post" action="{{ url_for('account_mark_all_unread') }}" style="display:inline">
+      <form method="post" action="{{ url_for('account_mark_all_unread') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="hs-action-btn">Mark all unread</button>
       </form>
       {% endif %}
     {% endif %}
+  </div>
+  <div class="hs-right">
     {% if channel_id %}
     <a class="hs-ext" href="https://www.youtube.com/channel/{{ channel_id }}" target="_blank" rel="noopener">&#9654; YouTube</a>
     {% endif %}


### PR DESCRIPTION
- Move buttons from hs-right into a new hs-center flex zone so they sit between the tab strip and the RSS button
- hs-left (flex:1) + hs-center (flex:0) + hs-right (flex:1) gives true visual centering
- Reset all browser button defaults on hs-action-btn (appearance, line-height, margin, vertical-align) so it renders identically to the hs-rss anchor pill

https://claude.ai/code/session_01DD7ZtzGsbBF7hwbSkZFZkJ