### PR TITLE
Fix hs-action-btn height: display:contents on form, line-height:1 on …

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -104,7 +104,7 @@ header {
 .hs-tab-active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 500; }
 /* Center: bulk action buttons */
 .hs-center { flex: 0 0 auto; display: flex; align-items: center; gap: 0.5rem; }
-.hs-center form { margin: 0; }
+.hs-center form { display: contents; }
 /* Right: RSS and external links */
 .hs-right { flex: 1; display: flex; align-items: center; justify-content: flex-end; gap: 0.75rem; }
 .hs-ext { font-weight: 400; font-size: 0.8rem; color: var(--muted); }
@@ -132,8 +132,7 @@ header {
   cursor: pointer;
   padding: 0.1rem 0.45rem;
   white-space: nowrap;
-  line-height: inherit;
-  vertical-align: baseline;
+  line-height: 1;
   margin: 0;
 }
 .hs-action-btn:hover { color: var(--text); border-color: var(--text); }


### PR DESCRIPTION
…button

display:contents removes the block-level form wrapper from layout so the button participates directly in the flex row. line-height:1 kills the OS-imposed intrinsic height that was making the button taller than the RSS pill anchor despite identical padding.

https://claude.ai/code/session_01DD7ZtzGsbBF7hwbSkZFZkJ