### PR TITLE
Fix mark-all and Run Now buttons to match btn-sm style

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -104,7 +104,6 @@ header {
 .hs-tab-active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 500; }
 /* Center: bulk action buttons */
 .hs-center { flex: 0 0 auto; display: flex; align-items: center; gap: 0.5rem; }
-.hs-center form { display: contents; }
 /* Right: RSS and external links */
 .hs-right { flex: 1; display: flex; align-items: center; justify-content: flex-end; gap: 0.75rem; }
 .hs-ext { font-weight: 400; font-size: 0.8rem; color: var(--muted); }
@@ -119,23 +118,6 @@ header {
   white-space: nowrap;
 }
 .hs-rss:hover { color: var(--text); border-color: var(--text); text-decoration: none; }
-.hs-action-btn {
-  appearance: none;
-  display: inline-block;
-  font-size: 0.75rem;
-  font-weight: 500;
-  font-family: inherit;
-  color: var(--muted);
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  cursor: pointer;
-  padding: 0.1rem 0.45rem;
-  white-space: nowrap;
-  line-height: 1;
-  margin: 0;
-}
-.hs-action-btn:hover { color: var(--text); border-color: var(--text); }
 
 /* Hamburger toggle — hidden on desktop */
 .nav-toggle {
@@ -565,6 +547,16 @@ button[type="submit"]:hover,
 }
 .btn-sm:visited { color: #fff; }
 .btn-sm:hover { background: var(--accent-hover); }
+/* Allow <button> elements to use the small style without being overridden
+   by the global button[type="submit"] rule */
+button.btn-sm {
+  margin-top: 0;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1;
+  transition: background 0.15s;
+}
 
 .btn-danger {
   padding: 0.6rem 1.25rem;

--- a/web/templates/admin_runs.html
+++ b/web/templates/admin_runs.html
@@ -30,7 +30,7 @@
     {% else %}
       <form method="post" action="{{ url_for('admin_run_now') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <button type="submit" class="btn-save">Run Now</button>
+        <button type="submit" class="btn-sm">Run Now</button>
       </form>
     {% endif %}
     {% if current_run_pid %}

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -18,15 +18,15 @@
   <div class="hs-center">
     {% if current_user.is_authenticated and not channel_id and stories %}
       {% if not is_archive %}
-      <form method="post" action="{{ url_for('account_mark_all_read') }}">
+      <form method="post" action="{{ url_for('account_mark_all_read') }}" style="display:contents">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <button type="submit" class="hs-action-btn">Mark all read</button>
+        <button type="submit" class="btn-sm">Mark all read</button>
       </form>
       {% endif %}
       {% if is_archive or is_all %}
-      <form method="post" action="{{ url_for('account_mark_all_unread') }}">
+      <form method="post" action="{{ url_for('account_mark_all_unread') }}" style="display:contents">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <button type="submit" class="hs-action-btn">Mark all unread</button>
+        <button type="submit" class="btn-sm">Mark all unread</button>
       </form>
       {% endif %}
     {% endif %}


### PR DESCRIPTION
The global button[type="submit"] rule was overriding everything. Fix: add button.btn-sm to reset margin/padding/line-height so submit buttons can use the small style. Switch all three problem buttons (mark all read, mark all unread, run now) to btn-sm. Use display:contents on the form wrappers in the sub-header so the buttons participate directly in the flex row without a block-level wrapper. Remove the dead hs-action-btn rules.

https://claude.ai/code/session_01DD7ZtzGsbBF7hwbSkZFZkJ