### PR TITLE
Split requirements: move pytest to requirements-dev.txt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,11 @@ Defined in `web/app.py`:
 ### Install Dependencies
 
 ```bash
+# Production
 pip install -r requirements.txt
+
+# Development (adds pytest)
+pip install -r requirements-dev.txt
 ```
 
 Packages install globally — no virtual environment is used.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 requests
 feedgen
 supadata
-pytest
 flask
 flask-login
 flask-wtf


### PR DESCRIPTION
Production installs only need requirements.txt. Development/testing uses requirements-dev.txt which pulls in requirements.txt via -r and adds pytest.

https://claude.ai/code/session_01DD7ZtzGsbBF7hwbSkZFZkJ