### PR TITLE
Add onboarding redirect for new users with no channel subscriptions

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -424,6 +424,39 @@ def test_login_valid_credentials_redirects(client, registered_user):
     assert r.status_code == 302
 
 
+def test_login_with_channels_redirects_to_blog(client, registered_user):
+    """Users who already have channel subscriptions land on /blog after login."""
+    r = client.post("/login", data={
+        "email": "test@example.com",
+        "password": "testpassword123",
+    }, follow_redirects=False)
+    assert r.status_code == 302
+    assert "/blog" in r.headers["Location"]
+
+
+def test_login_no_channels_redirects_to_account(client, archive):
+    """A user with no channel subscriptions is sent to /account on login (onboarding)."""
+    _make_user(archive / "_users", name="New User", email="new@example.com",
+               channel_ids=[], token="new-user-token")
+    r = client.post("/login", data={
+        "email": "new@example.com",
+        "password": "testpassword123",
+    }, follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["Location"].endswith("/account")
+
+
+def test_login_no_channels_shows_welcome_message(client, archive):
+    """A welcome flash message is shown when a channel-less user is redirected to /account."""
+    _make_user(archive / "_users", name="New User", email="new@example.com",
+               channel_ids=[], token="new-user-token")
+    r = client.post("/login", data={
+        "email": "new@example.com",
+        "password": "testpassword123",
+    }, follow_redirects=True)
+    assert b"Welcome" in r.data
+
+
 def test_login_wrong_password_shows_error(client, registered_user):
     r = client.post("/login", data={
         "email": "test@example.com",

--- a/web/app.py
+++ b/web/app.py
@@ -768,6 +768,9 @@ def login():
                 flash("This account has been locked. Contact an administrator.", "error")
             else:
                 login_user(user, remember=remember)
+                if not user.channel_ids:
+                    flash("Welcome! Choose the channels you'd like to follow below.", "success")
+                    return redirect(url_for("account"))
                 return redirect(_safe_next(request.args.get("next")))
         else:
             flash("Invalid email or password.", "error")
@@ -812,7 +815,7 @@ def register():
             _index_add(email, user_uuid)
             login_user(User(user_dir, data))
             _web_ntfy("TubeNews: new user", f"{name} ({email}) registered.")
-            flash("Account created. Choose your channels below.", "success")
+            flash("Account created! Choose the channels you'd like to follow below.", "success")
             return redirect(url_for("account"))
 
     return render_template("register.html")

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -487,6 +487,9 @@ button[type="submit"]:hover,
 
 .danger-zone { border-color: #fca5a5; background: #fff8f8; }
 
+.onboarding-banner { border-color: var(--accent); background: var(--info-bg); color: var(--info-text); }
+html.dark .onboarding-banner { background: var(--info-bg); color: var(--info-text); }
+
 .alert-danger {
   background: #fff0f0;
   border: 1px solid var(--danger);

--- a/web/templates/account.html
+++ b/web/templates/account.html
@@ -5,6 +5,14 @@
 <div class="admin">
   <h1>{{ current_user.name }}</h1>
 
+  {% if not current_user.channel_ids %}
+  <section class="admin-section onboarding-banner">
+    <h2>Get started</h2>
+    <p>Pick the channels you want to follow, then click <strong>Subscribe</strong>.
+       Your personal RSS feed and blog will be ready once you've saved at least one channel.</p>
+  </section>
+  {% endif %}
+
   <!-- ── Sharing URLs ───────────────────────────────────────── -->
   <section class="admin-section">
     <h2>Sharing URLs</h2>


### PR DESCRIPTION
Users who log in with no channels subscribed are redirected to /account (the feed picker) instead of /blog, with a welcome flash message. A blue "Get started" banner is also shown at the top of the account page when the user has no subscriptions yet. Registration flash message updated to match. Three new tests cover the redirect and welcome message.

https://claude.ai/code/session_013MhDdcx82GQiYBctvYCq46