### PR TITLE
Add story count badges to Unread and Starred tabs

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -102,6 +102,10 @@ header {
 .hs-tab { font-weight: 400; color: var(--muted); padding: 0 0.1rem; border-bottom: 2px solid transparent; line-height: 36px; }
 .hs-tab:hover { color: var(--text); text-decoration: none; }
 .hs-tab-active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 500; }
+.tab-count { font-size: 0.75em; font-weight: 600; border-radius: 8px; padding: 0 5px; margin-left: 3px; vertical-align: middle; background: #e5e7eb; color: #6b7280; }
+html.dark .tab-count { background: #374151; color: #9ca3af; }
+.hs-tab-active .tab-count { background: #dbeafe; color: #2563eb; }
+html.dark .hs-tab-active .tab-count { background: #1e3a5f; color: #60a5fa; }
 /* Center: bulk action buttons */
 .hs-center { flex: 0 0 auto; display: flex; align-items: center; gap: 0.5rem; }
 /* Right: RSS and external links */

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -6,8 +6,8 @@
   <div class="hs-left">
     <span class="hs-feed-name">{{ blog_name }}</span>
     {% if current_user.is_authenticated and not channel_id %}
-      <a class="hs-tab{% if not is_archive and not is_all and not is_starred %} hs-tab-active{% endif %}" href="{{ url_for('serve_blog') }}">Unread</a>
-      <a class="hs-tab{% if is_starred %} hs-tab-active{% endif %}" href="{{ url_for('serve_starred') }}">Starred</a>
+      <a class="hs-tab{% if not is_archive and not is_all and not is_starred %} hs-tab-active{% endif %}" href="{{ url_for('serve_blog') }}">Unread{% if not is_archive and not is_all and not is_starred %}<span class="tab-count" id="unread-badge"{% if not stories %} style="display:none"{% endif %}>{{ stories|length }}</span>{% endif %}</a>
+      <a class="hs-tab{% if is_starred %} hs-tab-active{% endif %}" href="{{ url_for('serve_starred') }}">Starred<span class="tab-count" id="starred-badge"{% if not starred_hashes %} style="display:none"{% endif %}>{{ starred_hashes|length }}</span></a>
       <a class="hs-tab{% if is_archive %} hs-tab-active{% endif %}" href="{{ url_for('serve_read') }}">Read</a>
       <a class="hs-tab{% if is_all %} hs-tab-active{% endif %}" href="{{ url_for('serve_all') }}">All</a>
     {% elif channel_id %}
@@ -239,6 +239,12 @@
   var markUnstarredUrl= {{ url_for('account_mark_unstarred')| tojson }};
   var isAll     = {{ (is_all     or False) | tojson }};
   var isStarred = {{ (is_starred or False) | tojson }};
+  var unreadBadgeEl  = document.getElementById('unread-badge');
+  var starredBadgeEl = document.getElementById('starred-badge');
+  function setBadge(el, n) {
+    el.textContent = n;
+    el.style.display = n > 0 ? '' : 'none';
+  }
 
   function postHash(url, hash, onSuccess) {
     var fd = new FormData();
@@ -269,7 +275,11 @@
   function fadeRemove(article) {
     article.style.transition = 'opacity 0.3s';
     article.style.opacity = '0';
-    setTimeout(function () { article.remove(); scrollToFocused(); }, 300);
+    setTimeout(function () {
+      article.remove();
+      if (unreadBadgeEl) setBadge(unreadBadgeEl, Math.max(0, parseInt(unreadBadgeEl.textContent || '0') - 1));
+      scrollToFocused();
+    }, 300);
   }
 
   function attachReadBtn(btn) {
@@ -320,6 +330,7 @@
         btn.className = 'share-unstarred';
         btn.title = 'Unstar';
         btn.innerHTML = '&#9733; Starred';
+        if (starredBadgeEl) setBadge(starredBadgeEl, parseInt(starredBadgeEl.textContent || '0') + 1);
         attachUnstarBtn(btn);
       });
     });
@@ -332,6 +343,7 @@
       if (!hash) return;
       postHash(markUnstarredUrl, hash, function () {
         btn.removeEventListener('click', handler);
+        if (starredBadgeEl) setBadge(starredBadgeEl, Math.max(0, parseInt(starredBadgeEl.textContent || '0') - 1));
         if (isStarred) {
           fadeRemove(btn.closest('article'));
         } else {


### PR DESCRIPTION
- Unread tab: shows count badge when active (/blog view); decrements live as stories are marked read via fadeRemove
- Starred tab: shows count badge on all views (starred_hashes already available everywhere); increments/decrements live as stories are starred/unstarred
- Badges hide (not "0") when count reaches zero
- CSS: .tab-count with light/dark mode and active/inactive tab variants

https://claude.ai/code/session_01MqW1mCUmcoVA7yeRTkaTLC