### PR TITLE
Fix 's' keyboard shortcut for starring stories

### DIFF
--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -528,6 +528,7 @@
 
   var pendingG = false;
   var gTimer   = null;
+  var isStarred = {{ (is_starred or False) | tojson }};
 
   document.addEventListener('keydown', function (e) {
     var tag = (e.target.tagName || '').toLowerCase();


### PR DESCRIPTION
isStarred was declared inside the auth IIFE (first <script> block) but referenced inside the keyboard shortcut IIFE (second <script> block), throwing a ReferenceError that silently aborted the handler before starBtn.click() could execute. Declare isStarred in the keyboard shortcut scope to fix it.

https://claude.ai/code/session_01MqW1mCUmcoVA7yeRTkaTLC