### PR TITLE
Permanently skip videos with no transcript available

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ Story body text in AP inverted pyramid style...
 }
 ```
 
-`status` values: `"processed"` | `"ignored_too_old"` | `"no_stories"` (AI ran but returned no relevant stories)
+`status` values: `"processed"` | `"ignored_too_old"` | `"no_stories"` (AI ran but returned no relevant stories) | `"no_transcript_available"` (Supadata confirmed no captions exist; will not be retried)
 
 `processed_focuses` is a sorted list of all focus strings for which Gemini has been called on this video. Old `metadata.json` files that pre-date this field have no `processed_focuses` key and are treated as fully processed (not re-run).
 

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -485,7 +485,7 @@ def fetch_transcript(
     feed_name: str = "",
     video_title: str = "",
     transcript_rate_limit_event: threading.Event | None = None,
-) -> str | None:
+) -> str | None | bool:
     """Fetch timed transcript segments from the Supadata API.
 
     Each segment is formatted as ``"<offset_seconds>s --> <text>"`` so Gemini
@@ -496,7 +496,11 @@ def fetch_transcript(
     *transcript_rate_limit_event* is set so that ``process_video`` and
     ``process_feed`` can abort remaining videos immediately.
 
-    Returns the formatted transcript string, or None if the API call fails.
+    Returns:
+        str  — formatted transcript on success.
+        None — transient failure (network error, rate limit, etc.); will retry next run.
+        False — permanent no-transcript (Supadata confirmed the video has no captions);
+                caller should write ``status: "no_transcript_available"`` and stop retrying.
     """
     prefix = ": ".join(p for p in [feed_name, video_title] if p)
     prefix = f"{prefix}: " if prefix else ""
@@ -531,6 +535,12 @@ def fetch_transcript(
             status = getattr(getattr(exc, "response", None), "status_code", None)
             is_quota_error = status == 402
 
+        # Detect permanent "no transcript" from SupadataError codes.
+        is_permanent_no_transcript = isinstance(exc, SupadataError) and (
+            exc.error == "transcript-unavailable"
+            or "not-found" in (exc.error or "")
+        )
+
         if is_quota_error:
             logger.error(
                 f"{prefix}Supadata: Quota exhausted — no credits remaining. "
@@ -538,6 +548,9 @@ def fetch_transcript(
             )
             if transcript_rate_limit_event is not None:
                 transcript_rate_limit_event.set()
+        elif is_permanent_no_transcript:
+            logger.info(f"{prefix}Supadata: No transcript available — marking permanent, will not retry")
+            return False
         elif "live streaming" in exc_str:
             logger.warning(f"{prefix}Supadata: Live stream — transcript unavailable, will retry next run")
         else:
@@ -1273,11 +1286,24 @@ def process_video(
             feed_name=channel_name, video_title=video_title,
             transcript_rate_limit_event=transcript_rate_limit_event,
         )
-        if not transcript_text:
-            # Distinguish quota exhaustion from ordinary fetch failure.
+        if transcript_text is False:
+            # Permanent: Supadata confirmed no transcript exists — never retry.
+            meeting_dir = feed_dir / f"{video_date}_{video_id}"
+            meeting_dir.mkdir(exist_ok=True)
+            metadata: MetadataDict = {
+                "video_id": video_id,
+                "video_title": video_title,
+                "status": "no_transcript_available",
+                "processed_at": time.time(),
+            }
+            (meeting_dir / "metadata.json").write_text(json.dumps(metadata))
+            logger.info(f"{channel_name}: [{video_id}] {video_title}: TubeNews: No transcript available — marked permanent, will not retry")
+            return "skipped", 0
+        elif not transcript_text:
+            # Transient failure — quota exhausted or network error, will retry next run.
             if transcript_rate_limit_event is not None and transcript_rate_limit_event.is_set():
                 return "transcript_quota_exhausted", 0
-            logger.info(f"{channel_name}: [{video_id}] {video_title}: Supadata: No transcript available — skipping")
+            logger.info(f"{channel_name}: [{video_id}] {video_title}: Supadata: Fetch failed — will retry next run")
             return "skipped", 0
 
         meeting_dir = feed_dir / f"{video_date}_{video_id}"

--- a/tests/test_tubenews.py
+++ b/tests/test_tubenews.py
@@ -1877,13 +1877,13 @@ def test_fetch_transcript_sets_quota_event_on_http_402(monkeypatch):
 
 
 def test_fetch_transcript_does_not_set_event_on_other_errors(monkeypatch):
-    """fetch_transcript does NOT set the event for non-quota errors (e.g. video not found)."""
+    """fetch_transcript does NOT set the event for generic transient errors."""
     import threading
     from supadata import SupadataError
 
     mock_client = type("C", (), {
         "transcript": staticmethod(lambda **kw: (_ for _ in ()).throw(
-            SupadataError(error="video-not-found", message="Not found", details="")
+            SupadataError(error="internal-error", message="Server error", details="")
         ))
     })()
 
@@ -1891,6 +1891,65 @@ def test_fetch_transcript_does_not_set_event_on_other_errors(monkeypatch):
     result = fetch_transcript("VID123", mock_client, transcript_rate_limit_event=event)
     assert result is None
     assert not event.is_set()
+
+
+def test_fetch_transcript_returns_false_for_transcript_unavailable():
+    """fetch_transcript returns False (permanent) for 'transcript-unavailable' error code."""
+    import threading
+    from supadata import SupadataError
+
+    for error_code in ("transcript-unavailable", "video-not-found"):
+        mock_client = type("C", (), {
+            "transcript": staticmethod(lambda **kw: (_ for _ in ()).throw(
+                SupadataError(error=error_code, message="No transcript", details="")
+            ))
+        })()
+        event = threading.Event()
+        result = fetch_transcript("VID123", mock_client, transcript_rate_limit_event=event)
+        assert result is False, f"Expected False for error_code={error_code!r}, got {result!r}"
+        assert not event.is_set(), "quota event must not be set for permanent no-transcript"
+
+
+def test_process_video_writes_no_transcript_metadata(tmp_path, monkeypatch):
+    """When fetch_transcript returns False, process_video writes metadata.json with
+    status 'no_transcript_available' and _needs_processing returns False afterward."""
+    import TubeNews
+    from TubeNews import _needs_processing
+
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+
+    feed = {"channel_id": "UCtest1234", "channel_name": "Test Channel", "focus": "housing"}
+    feed_dir = tmp_path / "test_channel"
+    feed_dir.mkdir()
+
+    monkeypatch.setattr(TubeNews, "fetch_transcript", lambda *a, **kw: False)
+
+    from unittest.mock import MagicMock
+    status, n = TubeNews.process_video(
+        video_id="VID_NO_TX",
+        video_title="March Meeting",
+        video_date="2026-03-01",
+        is_live=False,
+        feed=feed,
+        feed_dir=feed_dir,
+        supadata_client=MagicMock(),
+        config={"gemini_api_key": "k", "gemini_model": "m"},
+        ai_disabled=False,
+    )
+
+    assert status == "skipped"
+    assert n == 0
+
+    # metadata.json must exist with the correct status
+    meeting_dirs = [d for d in feed_dir.iterdir() if d.is_dir() and "VID_NO_TX" in d.name]
+    assert len(meeting_dirs) == 1, "Expected exactly one meeting directory"
+    import json
+    meta = json.loads((meeting_dirs[0] / "metadata.json").read_text())
+    assert meta["status"] == "no_transcript_available"
+    assert meta["video_id"] == "VID_NO_TX"
+
+    # _needs_processing must now return False — the video won't be retried
+    assert not _needs_processing("VID_NO_TX", feed_dir)
 
 
 def test_process_feed_stops_on_transcript_quota_exhausted(tmp_path, monkeypatch):


### PR DESCRIPTION
When Supadata raises SupadataError with error code "transcript-unavailable" or any "not-found" variant, fetch_transcript now returns False (permanent) instead of None (transient). process_video detects this and writes a metadata.json with status "no_transcript_available" so _needs_processing returns False and the video is never retried.

Previously these videos were retried on every run indefinitely since no metadata.json was written on transcript failure.

https://claude.ai/code/session_01MqW1mCUmcoVA7yeRTkaTLC