### PR TITLE
Expand permanent no-transcript detection to cover more cases

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -522,6 +522,10 @@ def fetch_transcript(
             transcript_text = "\n".join(lines)
             logger.info(f"{prefix}Supadata: Transcript ready — {len(segments)} segments, {len(transcript_text):,} chars")
             return transcript_text
+        else:
+            # API returned a response but no transcript content — video has no captions.
+            logger.info(f"{prefix}Supadata: No transcript available — marking permanent, will not retry")
+            return False
     except Exception as exc:
         exc_str = str(exc).lower()
         # Detect quota / credit exhaustion from SupadataError or HTTP 402/429.
@@ -538,6 +542,7 @@ def fetch_transcript(
         # Detect permanent "no transcript" from SupadataError codes.
         is_permanent_no_transcript = isinstance(exc, SupadataError) and (
             exc.error == "transcript-unavailable"
+            or exc.error == "forbidden"
             or "not-found" in (exc.error or "")
         )
 

--- a/tests/test_tubenews.py
+++ b/tests/test_tubenews.py
@@ -1894,11 +1894,11 @@ def test_fetch_transcript_does_not_set_event_on_other_errors(monkeypatch):
 
 
 def test_fetch_transcript_returns_false_for_transcript_unavailable():
-    """fetch_transcript returns False (permanent) for 'transcript-unavailable' error code."""
+    """fetch_transcript returns False (permanent) for known permanent error codes."""
     import threading
     from supadata import SupadataError
 
-    for error_code in ("transcript-unavailable", "video-not-found"):
+    for error_code in ("transcript-unavailable", "video-not-found", "forbidden"):
         mock_client = type("C", (), {
             "transcript": staticmethod(lambda **kw: (_ for _ in ()).throw(
                 SupadataError(error=error_code, message="No transcript", details="")
@@ -1908,6 +1908,17 @@ def test_fetch_transcript_returns_false_for_transcript_unavailable():
         result = fetch_transcript("VID123", mock_client, transcript_rate_limit_event=event)
         assert result is False, f"Expected False for error_code={error_code!r}, got {result!r}"
         assert not event.is_set(), "quota event must not be set for permanent no-transcript"
+
+
+def test_fetch_transcript_returns_false_for_empty_content():
+    """fetch_transcript returns False (permanent) when API returns a response with no content."""
+    # Simulate a successful API call that returns a transcript object with no content
+    empty_response = type("T", (), {"content": None, "lang": "en"})()
+    mock_client = type("C", (), {
+        "transcript": staticmethod(lambda **kw: empty_response)
+    })()
+    result = fetch_transcript("VID123", mock_client)
+    assert result is False
 
 
 def test_process_video_writes_no_transcript_metadata(tmp_path, monkeypatch):


### PR DESCRIPTION
Two gaps in the previous fix:
- Empty content response (API returns 200 but no transcript content) was falling through to return None (transient). Now returns False (permanent). This is what happens with short YouTube videos that have no captions.
- SupadataError with error="forbidden" (age-restricted videos requiring auth) was not in the permanent patterns. Now treated as permanent since Supadata will never be able to fetch these without authentication.

https://claude.ai/code/session_01MqW1mCUmcoVA7yeRTkaTLC