### PR TITLE
Add channel sidebar to blog views with per-view filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Defined in `web/app.py`:
 |---|---|---|
 | `ChannelInfo` | `channel_id`, `channel_name` (both `str`) | `_channel_info_for_dir()` return type |
 | `ChannelStat` | `channel_id`, `channel_name`, `processed`, `ignored`, `no_stories`, `story_count` (`int`), `last_processed` (`float`) | `_archive_channel_stats()` return type |
-| `StoryDict` | `title`, `dateline`, `body_html`, `video_id`, `video_title`, `channel_name`, `channel_slug`, `meeting_id`, `story_filename` (`str`), `start_seconds` (`int`), `processed_at` (`float`), `content_hash` (`str`) | `_get_user_stories()` and `_get_channel_stories()` return type; passed to Flask templates |
+| `StoryDict` | `title`, `dateline`, `body_html`, `video_id`, `video_title`, `channel_name`, `channel_slug`, `meeting_id`, `story_filename`, `channel_id` (`str`), `start_seconds` (`int`), `processed_at` (`float`), `content_hash` (`str`) | `_get_user_stories()` and `_get_channel_stories()` return type; passed to Flask templates |
 
 ---
 
@@ -485,6 +485,7 @@ the web app does **not** call either — the web UI uses dynamic generation only
 | `_archive_channel_stats()` | Scans all channel directories and returns `list[ChannelStat]` with per-channel counts of processed, ignored, no-stories, and story files. Used by `admin_feeds`. |
 | `_get_channel_stories(channel_id)` | Returns `(channel_name | None, list[StoryDict])` for a single channel. Used by `channel_blog`. |
 | `_get_user_stories(user_data, user_id)` | Scans all subscribed channel directories and returns `list[StoryDict]` filtered by the user's `user_ids` attribution. Used by `serve_blog`, `serve_read`, `serve_all`, and the public blog route. |
+| `_channel_counts(stories)` | Takes a `list[StoryDict]` and returns `list[dict]` with `channel_id`, `channel_name`, and `count` keys, sorted by count descending. Used by all four blog routes to populate the channel sidebar. |
 | `_get_supadata_balance()` | Reads the cached Supadata credit data from `content/_run_logs/supadata_balance.json`; returns `None` if absent. Used by `admin_feeds` to show the credit balance without a live API call. |
 
 ### Route Map
@@ -507,10 +508,10 @@ the web app does **not** call either — the web UI uses dynamic generation only
 |---|---|---|---|
 | GET/POST | `/dashboard` | `dashboard` | Subscribe to channels; shows feed and blog URLs |
 | POST | `/logout` | `logout` | Clears session (POST + CSRF to prevent logout CSRF) |
-| GET | `/blog` | `serve_blog` | Serves the logged-in user's unread (inbox) stories |
-| GET | `/starred` | `serve_starred` | Serves the logged-in user's starred stories |
-| GET | `/read` | `serve_read` | Serves the logged-in user's read stories (the "Read" tab) |
-| GET | `/all` | `serve_all` | Serves all of the logged-in user's stories regardless of read status |
+| GET | `/blog` | `serve_blog` | Serves the logged-in user's unread (inbox) stories; accepts `?channel=<channel_id>` to filter to a single channel |
+| GET | `/starred` | `serve_starred` | Serves the logged-in user's starred stories; accepts `?channel=<channel_id>` to filter to a single channel |
+| GET | `/read` | `serve_read` | Serves the logged-in user's read stories (the "Read" tab); accepts `?channel=<channel_id>` to filter to a single channel |
+| GET | `/all` | `serve_all` | Serves all of the logged-in user's stories regardless of read status; accepts `?channel=<channel_id>` to filter to a single channel (applied after any `?q=` search) |
 | GET | `/channel/<channel_id>` | `channel_blog` | Browse all stories for one channel (no time cutoff); passes `channel_id` to `blog.html` so the sub-header can link to the YouTube channel page |
 | GET/POST | `/account` | `account` | Self-service account settings: change name/email (requires current password) |
 | POST | `/account/password` | `account_password` | Change own password (requires current password; new password min 10 chars) |

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -2478,3 +2478,145 @@ def test_mark_unstarred_removes_hash(logged_in_client, archive, monkeypatch):
         if d.get("email") == "test@example.com":
             assert "abc123" not in d.get("starred_articles", [])
             break
+
+
+# ---------------------------------------------------------------------------
+# Channel sidebar — _channel_counts, channel_id in StoryDict, ?channel= filter
+# ---------------------------------------------------------------------------
+
+
+def test_channel_counts_groups_and_sorts():
+    """_channel_counts must group by channel_id and sort highest-count first."""
+    stories = [
+        {"channel_id": "UC_A", "channel_name": "Alpha", "title": "S1", "dateline": "",
+         "body_html": "", "start_seconds": 0, "video_id": "v1", "video_title": "",
+         "channel_slug": "alpha", "meeting_id": "m1", "story_filename": "01.md",
+         "processed_at": 0, "content_hash": "h1"},
+        {"channel_id": "UC_A", "channel_name": "Alpha", "title": "S2", "dateline": "",
+         "body_html": "", "start_seconds": 0, "video_id": "v2", "video_title": "",
+         "channel_slug": "alpha", "meeting_id": "m1", "story_filename": "02.md",
+         "processed_at": 0, "content_hash": "h2"},
+        {"channel_id": "UC_B", "channel_name": "Beta", "title": "S3", "dateline": "",
+         "body_html": "", "start_seconds": 0, "video_id": "v3", "video_title": "",
+         "channel_slug": "beta", "meeting_id": "m2", "story_filename": "01.md",
+         "processed_at": 0, "content_hash": "h3"},
+    ]
+    counts = webapp._channel_counts(stories)
+    assert len(counts) == 2
+    assert counts[0]["channel_id"] == "UC_A"
+    assert counts[0]["count"] == 2
+    assert counts[1]["channel_id"] == "UC_B"
+    assert counts[1]["count"] == 1
+
+
+def test_channel_counts_empty():
+    """_channel_counts must return an empty list when given no stories."""
+    assert webapp._channel_counts([]) == []
+
+
+def test_get_user_stories_includes_channel_id(archive, monkeypatch):
+    """_get_user_stories must include channel_id in every returned story dict."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    user_data = {"channels": {"UC_ALPHA_ID": []}}
+    stories = _wa._get_user_stories(user_data)
+    assert stories, "Expected at least one story from alpha channel"
+    for s in stories:
+        assert "channel_id" in s
+        assert s["channel_id"] == "UC_ALPHA_ID"
+
+
+def test_serve_blog_channel_filter_returns_only_that_channel(client, archive, monkeypatch):
+    """/blog?channel=<id> must return only stories from the specified channel."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    _make_user(archive / "_users", "Multi User", "multi@example.com",
+               ["UC_ALPHA_ID", "UC_BETA__ID"], token="multi-token-abc")
+    client.post("/login", data={"email": "multi@example.com", "password": "testpassword123"})
+    r = client.get("/blog?channel=UC_ALPHA_ID")
+    assert r.status_code == 200
+    assert b"Alpha Council Approves Budget" in r.data
+    assert b"Beta Council Discusses Zoning" not in r.data
+
+
+def test_serve_blog_channel_filter_unknown_returns_404(client, archive, monkeypatch):
+    """/blog?channel=<unknown> must return 404."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    _make_user(archive / "_users", "Multi User", "multi2@example.com",
+               ["UC_ALPHA_ID", "UC_BETA__ID"], token="multi-token-xyz")
+    client.post("/login", data={"email": "multi2@example.com", "password": "testpassword123"})
+    r = client.get("/blog?channel=UC_NO_SUCH_ID")
+    assert r.status_code == 404
+
+
+def test_serve_blog_includes_sidebar_with_multiple_channels(client, archive, monkeypatch):
+    """/blog must render the channel sidebar when the user has stories from multiple channels."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    _make_user(archive / "_users", "Multi User", "multi3@example.com",
+               ["UC_ALPHA_ID", "UC_BETA__ID"], token="multi-token-def")
+    client.post("/login", data={"email": "multi3@example.com", "password": "testpassword123"})
+    r = client.get("/blog")
+    assert r.status_code == 200
+    assert b"channel-sidebar" in r.data
+    assert b"Alpha City Council" in r.data
+    assert b"Beta City Council" in r.data
+
+
+def test_serve_all_channel_filter_returns_only_that_channel(client, archive, monkeypatch):
+    """/all?channel=<id> must return only stories from the specified channel."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    _make_user(archive / "_users", "Multi User", "multi4@example.com",
+               ["UC_ALPHA_ID", "UC_BETA__ID"], token="multi-token-ghi")
+    client.post("/login", data={"email": "multi4@example.com", "password": "testpassword123"})
+    r = client.get("/all?channel=UC_BETA__ID")
+    assert r.status_code == 200
+    assert b"Beta Council Discusses Zoning" in r.data
+    assert b"Alpha Council Approves Budget" not in r.data
+
+
+def test_serve_read_channel_filter(client, archive, monkeypatch):
+    """/read?channel=<id> must show only read stories from the specified channel."""
+    import web.app as _wa
+    import TubeNews as _tn
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+    _make_user(archive / "_users", "Multi User", "multi5@example.com",
+               ["UC_ALPHA_ID", "UC_BETA__ID"], token="multi-token-jkl")
+    client.post("/login", data={"email": "multi5@example.com", "password": "testpassword123"})
+    # Mark the alpha story as read.
+    story_file = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    parsed = _tn.parse_story_file(story_file)
+    client.post("/account/mark-read", data={"content_hash": parsed["content_hash"]})
+    r = client.get("/read?channel=UC_ALPHA_ID")
+    assert r.status_code == 200
+    assert b"Alpha Council Approves Budget" in r.data
+    assert b"Beta Council Discusses Zoning" not in r.data
+
+
+def test_serve_starred_channel_filter(client, archive, monkeypatch):
+    """/starred?channel=<id> must show only starred stories from the specified channel."""
+    import web.app as _wa
+    import TubeNews as _tn
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+    _make_user(archive / "_users", "Multi User", "multi6@example.com",
+               ["UC_ALPHA_ID", "UC_BETA__ID"], token="multi-token-mno")
+    client.post("/login", data={"email": "multi6@example.com", "password": "testpassword123"})
+    # Star the alpha story.
+    story_file = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    parsed = _tn.parse_story_file(story_file)
+    client.post("/account/mark-starred", data={"content_hash": parsed["content_hash"]})
+    r = client.get("/starred?channel=UC_ALPHA_ID")
+    assert r.status_code == 200
+    assert b"Alpha Council Approves Budget" in r.data
+    assert b"Beta Council Discusses Zoning" not in r.data

--- a/web/app.py
+++ b/web/app.py
@@ -204,6 +204,7 @@ class StoryDict(TypedDict):
     story_filename: str
     processed_at: float
     content_hash: str
+    channel_id: str
 
 
 # ---------------------------------------------------------------------------
@@ -543,6 +544,17 @@ def _archive_channel_stats() -> list[ChannelStat]:
     return sorted(stats, key=lambda s: s["channel_name"].lower())
 
 
+def _channel_counts(stories: list[StoryDict]) -> list[dict]:
+    """Return [{channel_id, channel_name, count}] sorted by count descending."""
+    mapping: dict[str, dict] = {}
+    for s in stories:
+        cid = s["channel_id"]
+        if cid not in mapping:
+            mapping[cid] = {"channel_id": cid, "channel_name": s["channel_name"], "count": 0}
+        mapping[cid]["count"] += 1
+    return sorted(mapping.values(), key=lambda c: c["count"], reverse=True)
+
+
 def _get_channel_stories(channel_id: str) -> tuple[str | None, list[StoryDict]]:
     """Return (channel_name, stories) for a single channel, newest-first.
 
@@ -570,6 +582,7 @@ def _get_channel_stories(channel_id: str) -> tuple[str | None, list[StoryDict]]:
                     continue
                 for story_file in meeting_dir.glob("[0-9]*.md"):
                     raw.append({"file": story_file, "meta": meta, "channel_name": channel_name,
+                                "channel_id": channel_id,
                                 "channel_slug": channel_dir.name, "meeting_id": meeting_dir.name})
             except Exception as exc:
                 logger.debug(f"Skipping {meeting_dir}: {exc}")
@@ -593,6 +606,7 @@ def _get_channel_stories(channel_id: str) -> tuple[str | None, list[StoryDict]]:
                     "meeting_id": entry.get("meeting_id", ""),
                     "story_filename": entry["file"].name,
                     "processed_at": entry["meta"].get("processed_at", 0),
+                    "channel_id": channel_id,
                 })
             except Exception as exc:
                 logger.debug(f"Skipping {entry['file']}: {exc}")
@@ -654,6 +668,7 @@ def _get_user_stories(user_data: dict, user_id: str = "") -> list[StoryDict]:
                 "story_filename": entry["file"].name,
                 "processed_at": entry["meta"].get("processed_at", 0),
                 "content_hash": s.get("content_hash", ""),
+                "channel_id": entry["channel_id"],
             })
         except Exception as exc:
             logger.debug(f"Skipping {entry['file']}: {exc}")
@@ -883,9 +898,17 @@ def serve_blog():
     read_count = len(all_stories) - len(stories)
     starred_hashes = set(current_user._data.get("starred_articles", []))
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
+    counts = _channel_counts(stories)
+    active_channel_id = request.args.get("channel", "")
+    if active_channel_id:
+        if not any(s["channel_id"] == active_channel_id for s in stories):
+            abort(404)
+        stories = [s for s in stories if s["channel_id"] == active_channel_id]
     return render_template("blog.html", stories=stories, blog_name=blog_name,
                            feed_path=f"/feed/{current_user.feed_token}.xml",
-                           read_count=read_count, starred_hashes=starred_hashes)
+                           read_count=read_count, starred_hashes=starred_hashes,
+                           channel_counts=counts, active_channel_id=active_channel_id,
+                           current_view_url=url_for("serve_blog"))
 
 
 @app.route("/read")
@@ -899,9 +922,17 @@ def serve_read():
     stories = [s for s in all_stories if s.get("content_hash", "") in read_set]
     starred_hashes = set(current_user._data.get("starred_articles", []))
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
+    counts = _channel_counts(stories)
+    active_channel_id = request.args.get("channel", "")
+    if active_channel_id:
+        if not any(s["channel_id"] == active_channel_id for s in stories):
+            abort(404)
+        stories = [s for s in stories if s["channel_id"] == active_channel_id]
     return render_template("blog.html", stories=stories, blog_name=blog_name,
                            feed_path=f"/feed/{current_user.feed_token}.xml",
-                           is_archive=True, starred_hashes=starred_hashes)
+                           is_archive=True, starred_hashes=starred_hashes,
+                           channel_counts=counts, active_channel_id=active_channel_id,
+                           current_view_url=url_for("serve_read"))
 
 
 @app.route("/all")
@@ -921,9 +952,18 @@ def serve_all():
                    q in s["dateline"].lower()]
     starred_hashes = set(current_user._data.get("starred_articles", []))
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
+    counts = _channel_counts(stories)
+    active_channel_id = request.args.get("channel", "")
+    if active_channel_id:
+        if not any(s["channel_id"] == active_channel_id for s in stories):
+            abort(404)
+        stories = [s for s in stories if s["channel_id"] == active_channel_id]
+    current_view = url_for("serve_all", q=query) if query else url_for("serve_all")
     return render_template("blog.html", stories=stories, blog_name=blog_name,
                            feed_path=f"/feed/{current_user.feed_token}.xml",
-                           is_all=True, query=query, starred_hashes=starred_hashes)
+                           is_all=True, query=query, starred_hashes=starred_hashes,
+                           channel_counts=counts, active_channel_id=active_channel_id,
+                           current_view_url=current_view)
 
 
 @app.route("/starred")
@@ -936,9 +976,17 @@ def serve_starred():
     all_stories = _get_user_stories(current_user._data, current_user.get_id())
     stories = [s for s in all_stories if s.get("content_hash", "") in starred_set]
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
+    counts = _channel_counts(stories)
+    active_channel_id = request.args.get("channel", "")
+    if active_channel_id:
+        if not any(s["channel_id"] == active_channel_id for s in stories):
+            abort(404)
+        stories = [s for s in stories if s["channel_id"] == active_channel_id]
     return render_template("blog.html", stories=stories, blog_name=blog_name,
                            feed_path=f"/feed/{current_user.feed_token}.xml",
-                           is_starred=True, starred_hashes=starred_set)
+                           is_starred=True, starred_hashes=starred_set,
+                           channel_counts=counts, active_channel_id=active_channel_id,
+                           current_view_url=url_for("serve_starred"))
 
 
 @app.route("/channel/<channel_id>")

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -630,6 +630,96 @@ button.btn-danger-sm:hover { background: #fee2e2; }
 
 .blog-meta a { color: var(--accent); }
 
+/* ---- Channel sidebar layout ---- */
+.blog-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.blog-page {
+  flex: 1;
+  min-width: 0;
+  max-width: 640px;
+}
+
+.channel-sidebar {
+  width: 180px;
+  flex-shrink: 0;
+  position: sticky;
+  top: 88px; /* 52px header + 36px sub-header */
+  max-height: calc(100vh - 96px);
+  overflow-y: auto;
+  padding: 0.5rem 0;
+}
+
+.sidebar-channel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  color: var(--text);
+  text-decoration: none;
+  gap: 0.4rem;
+}
+
+.sidebar-channel:hover { background: var(--border); }
+
+.sc-active {
+  background: var(--border);
+  font-weight: 600;
+}
+
+.sc-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sc-count {
+  font-size: 0.75rem;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 10px;
+  padding: 0.05rem 0.4rem;
+  flex-shrink: 0;
+}
+
+.sidebar-toggle { display: none; }
+
+@media (max-width: 700px) {
+  .blog-layout { display: block; }
+
+  .channel-sidebar {
+    display: none;
+    position: static;
+    width: 100%;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .channel-sidebar.sidebar-open { display: block; }
+
+  .sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    background: none;
+    border: none;
+    font-size: 1rem;
+    cursor: pointer;
+    color: var(--text);
+    padding: 0 0.4rem;
+  }
+}
+/* ---- End channel sidebar ---- */
+
 .story {
   padding: 1.5rem 0;
   border-bottom: 1px solid var(--border);

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -4,6 +4,9 @@
 {% block header_sub %}
 <div class="header-sub">
   <div class="hs-left">
+    {% if channel_counts is defined and channel_counts and not channel_id %}
+    <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle channel list" aria-expanded="false">&#9776;</button>
+    {% endif %}
     <span class="hs-feed-name">{{ blog_name }}</span>
     {% if current_user.is_authenticated and not channel_id %}
       <a class="hs-tab{% if not is_archive and not is_all and not is_starred %} hs-tab-active{% endif %}" href="{{ url_for('serve_blog') }}">Unread{% if not is_archive and not is_all and not is_starred %}<span class="tab-count" id="unread-badge"{% if not stories %} style="display:none"{% endif %}>{{ stories|length }}</span>{% endif %}</a>
@@ -52,6 +55,20 @@
 {% endblock %}
 
 {% block content %}
+<div class="blog-layout">
+{% if channel_counts is defined and channel_counts and not channel_id %}
+<aside class="channel-sidebar" id="channel-sidebar">
+  <a class="sidebar-channel{% if not active_channel_id %} sc-active{% endif %}"
+     href="{{ current_view_url }}">All channels</a>
+  {% for ch in channel_counts %}
+  <a class="sidebar-channel{% if active_channel_id == ch.channel_id %} sc-active{% endif %}"
+     href="{{ current_view_url }}?channel={{ ch.channel_id }}">
+    <span class="sc-name">{{ ch.channel_name }}</span>
+    <span class="sc-count">{{ ch.count }}</span>
+  </a>
+  {% endfor %}
+</aside>
+{% endif %}
 <div class="blog-page">
 
   {% if query is defined and query %}
@@ -121,7 +138,8 @@
     <p class="blog-empty">No unread stories.{% if read_count %} <a href="{{ url_for('serve_read') }}">View {{ read_count }} archived article{% if read_count != 1 %}s{% endif %}</a>.{% else %} Check back after the next TubeNews run.{% endif %}</p>
     {% endif %}
   {% endif %}
-</div>
+</div>{# end .blog-page #}
+</div>{# end .blog-layout #}
 
 <script>
 (function () {
@@ -606,6 +624,15 @@
         if (delBtn) delBtn.click();
       }
     }
+  });
+})();
+(function () {
+  var btn = document.getElementById('sidebar-toggle');
+  var sb = document.getElementById('channel-sidebar');
+  if (!btn || !sb) return;
+  btn.addEventListener('click', function () {
+    var open = sb.classList.toggle('sidebar-open');
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
   });
 })();
 </script>


### PR DESCRIPTION
All four blog views (/blog, /read, /starred, /all) now show a sticky left sidebar listing the user's channels with a count badge reflecting the number of stories visible in the current view. Clicking a channel adds ?channel=<id> to filter the view to that channel only. On mobile (≤700px) the sidebar is hidden by default with a hamburger toggle in the sub-header.

Implementation:
- Add channel_id field to StoryDict and populate in _get_user_stories and _get_channel_stories
- Add _channel_counts() helper that groups stories by channel and sorts by count descending
- Update serve_blog, serve_read, serve_starred, serve_all to compute channel_counts, accept ?channel= param, and pass sidebar context vars
- Add .blog-layout / .channel-sidebar CSS with sticky positioning and mobile collapse styles
- Add 8 new tests covering _channel_counts, channel_id in StoryDict, and ?channel= filtering on all four routes

https://claude.ai/code/session_01ScArKBEbSqhuf5L8G9SCCA