### PR TITLE
Focus story on click for keyboard navigation

### DIFF
--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -552,6 +552,14 @@
     if (!goNext) { scrollToStory(target); focusIdx = idx - 1; }
   }
 
+  // Clicking story text (not a button/link) focuses that story for keyboard nav.
+  document.querySelectorAll('article.story').forEach(function (article, idx) {
+    article.addEventListener('click', function (e) {
+      if (e.target.closest('a, button, input, select, textarea')) return;
+      setFocus(idx);
+    });
+  });
+
   function showHelp() { helpEl.style.display = 'flex'; }
   function hideHelp() { helpEl.style.display = 'none'; }
 


### PR DESCRIPTION
Clicking any non-interactive part of a story (title, body, dateline, source line) now calls setFocus() for that article, giving it the blue outline ring and setting focusIdx so j/k/arrow navigation continues from there. Clicks on links, buttons, and form elements are ignored by the guard so share/read/star actions are unaffected.

https://claude.ai/code/session_01ScArKBEbSqhuf5L8G9SCCA