### PR TITLE
Include channel_id in scraper warning; dump_channel_html accepts chan…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ Story body text in AP inverted pyramid style...
 |---|---|---|
 | `helpers/catchup.py` | Marks all visible videos as ignored | Before first run on a channel with existing videos |
 | `helpers/check_quota.py` | Tests Gemini API key quota across models | When AI calls fail with 429 errors |
-| `helpers/dump_channel_html.py` | Dumps raw `ytInitialData` JSON for the first configured channel | When YouTube scraper stops finding videos/titles — inspect structure changes |
+| `helpers/dump_channel_html.py` | Dumps raw `ytInitialData` JSON for a channel; accepts optional `channel_id` positional arg, falls back to first configured channel | When YouTube scraper stops finding videos/titles — inspect structure changes |
 | `helpers/reset_password.py` | Resets a user's password from the CLI | When the admin is locked out and can't log in to use the admin panel |
 
 ---

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -459,7 +459,8 @@ def discover_videos(channel_id: str, feed_name: str = "") -> list[VideoInfo]:
             logger.warning(
                 f"{prefix}YouTube: Found {len(found)} video ID(s) on {tab} tab "
                 "but could not parse any titles or dates — "
-                "YouTube HTML structure may have changed (run dump_channel_html.py to inspect)."
+                "YouTube HTML structure may have changed "
+                f"(run: python3 helpers/dump_channel_html.py {channel_id})."
             )
         meta_lookup.update(tab_meta)
         all_ids.extend(found)

--- a/helpers/dump_channel_html.py
+++ b/helpers/dump_channel_html.py
@@ -10,9 +10,13 @@ you can update ``_parse_channel_page_metadata()`` accordingly.
 
 Usage::
 
-    python3 helpers/dump_channel_html.py
+    python3 helpers/dump_channel_html.py [channel_id]
 
-Reads the first channel from ``TubeNews.json`` and writes two files:
+If ``channel_id`` is omitted, reads the first channel from ``TubeNews.json``.
+Pass a channel ID directly to inspect any channel without editing the config
+(e.g. when the warning log tells you which channel triggered the error).
+
+Writes two files:
 
 * ``/tmp/yt_data.json`` — the full ``ytInitialData`` blob (pretty-printed).
   Open this in a text editor or ``jq`` to explore the structure.
@@ -69,19 +73,24 @@ def find_video_renderers(obj: object, found: list | None = None) -> list[dict]:
 
 
 def main() -> None:
-    try:
-        config = json.loads(CONFIG_FILE.read_text())
-    except FileNotFoundError:
-        sys.exit(f"Error: {CONFIG_FILE} not found — copy TubeNews.json.sample first.")
-    except json.JSONDecodeError as exc:
-        sys.exit(f"Error: could not parse {CONFIG_FILE}: {exc}")
+    if len(sys.argv) > 1:
+        channel_id = sys.argv[1]
+        channel_name = channel_id  # no friendly name available from CLI
+    else:
+        try:
+            config = json.loads(CONFIG_FILE.read_text())
+        except FileNotFoundError:
+            sys.exit(f"Error: {CONFIG_FILE} not found — copy TubeNews.json.sample first.")
+        except json.JSONDecodeError as exc:
+            sys.exit(f"Error: could not parse {CONFIG_FILE}: {exc}")
 
-    feeds = config.get("feeds", [])
-    if not feeds:
-        sys.exit("No feeds configured in TubeNews.json — nothing to fetch.")
+        feeds = config.get("feeds", [])
+        if not feeds:
+            sys.exit("No feeds configured in TubeNews.json — nothing to fetch.")
 
-    channel_id = feeds[0]["channel_id"]
-    channel_name = feeds[0]["channel_name"]
+        channel_id = feeds[0]["channel_id"]
+        channel_name = feeds[0]["channel_name"]
+
     print(f"Channel : {channel_name}  ({channel_id})")
 
     url = f"https://www.youtube.com/channel/{channel_id}/videos"


### PR DESCRIPTION
…nel_id arg

- discover_videos(): warning now reads "run: python3 helpers/dump_channel_html.py <channel_id>" so the operator can copy-paste the exact command
- dump_channel_html.py: accepts an optional positional channel_id argument; falls back to the first configured feed when omitted (existing behaviour)
- CLAUDE.md: updated helper table entry to document the new argument

https://claude.ai/code/session_01ScArKBEbSqhuf5L8G9SCCA