### PR TITLE
Add tab argument to dump_channel_html.py; warning includes tab name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ Story body text in AP inverted pyramid style...
 |---|---|---|
 | `helpers/catchup.py` | Marks all visible videos as ignored | Before first run on a channel with existing videos |
 | `helpers/check_quota.py` | Tests Gemini API key quota across models | When AI calls fail with 429 errors |
-| `helpers/dump_channel_html.py` | Dumps raw `ytInitialData` JSON for a channel; accepts optional `channel_id` positional arg, falls back to first configured channel | When YouTube scraper stops finding videos/titles — inspect structure changes |
+| `helpers/dump_channel_html.py` | Dumps raw `ytInitialData` JSON for a channel tab; accepts optional `channel_id` and `tab` (`videos`\|`streams`) positional args, falls back to first configured channel / videos tab | When YouTube scraper stops finding videos/titles — inspect structure changes |
 | `helpers/reset_password.py` | Resets a user's password from the CLI | When the admin is locked out and can't log in to use the admin panel |
 
 ---

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -460,7 +460,7 @@ def discover_videos(channel_id: str, feed_name: str = "") -> list[VideoInfo]:
                 f"{prefix}YouTube: Found {len(found)} video ID(s) on {tab} tab "
                 "but could not parse any titles or dates — "
                 "YouTube HTML structure may have changed "
-                f"(run: python3 helpers/dump_channel_html.py {channel_id})."
+                f"(run: python3 helpers/dump_channel_html.py {channel_id} {tab})."
             )
         meta_lookup.update(tab_meta)
         all_ids.extend(found)

--- a/helpers/dump_channel_html.py
+++ b/helpers/dump_channel_html.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Dump the raw ``ytInitialData`` JSON from a channel's ``/videos`` page.
+"""Dump the raw ``ytInitialData`` JSON from a channel tab page.
 
 Use this when the YouTube scraper in ``TubeNews.py`` stops discovering
 videos or stops extracting titles and dates correctly.  YouTube embeds
@@ -10,15 +10,16 @@ you can update ``_parse_channel_page_metadata()`` accordingly.
 
 Usage::
 
-    python3 helpers/dump_channel_html.py [channel_id]
+    python3 helpers/dump_channel_html.py [channel_id [tab]]
 
-If ``channel_id`` is omitted, reads the first channel from ``TubeNews.json``.
-Pass a channel ID directly to inspect any channel without editing the config
-(e.g. when the warning log tells you which channel triggered the error).
+``tab`` is ``videos`` (default) or ``streams``.  If ``channel_id`` is
+omitted, reads the first channel from ``TubeNews.json``.  When the warning
+log tells you which channel and tab triggered the error, copy-paste the
+suggested command directly — it now includes both.
 
 Writes two files:
 
-* ``/tmp/yt_data.json`` — the full ``ytInitialData`` blob (pretty-printed).
+* ``/tmp/yt_data_<tab>.json`` — the full ``ytInitialData`` blob (pretty-printed).
   Open this in a text editor or ``jq`` to explore the structure.
 * ``/tmp/yt_raw.html`` — the raw page HTML, written only if the blob is not
   found (e.g. YouTube served a bot-detection interstitial instead).
@@ -91,9 +92,14 @@ def main() -> None:
         channel_id = feeds[0]["channel_id"]
         channel_name = feeds[0]["channel_name"]
 
-    print(f"Channel : {channel_name}  ({channel_id})")
+    tab = sys.argv[2] if len(sys.argv) > 2 else "videos"
+    if tab not in {"videos", "streams"}:
+        sys.exit(f"Error: tab must be 'videos' or 'streams', got {tab!r}.")
 
-    url = f"https://www.youtube.com/channel/{channel_id}/videos"
+    print(f"Channel : {channel_name}  ({channel_id})")
+    print(f"Tab     : {tab}")
+
+    url = f"https://www.youtube.com/channel/{channel_id}/{tab}"
     print(f"Fetching {url} …")
     try:
         r = requests.get(url, headers=HEADERS, timeout=15)
@@ -124,7 +130,7 @@ def main() -> None:
     except json.JSONDecodeError as exc:
         sys.exit(f"Found ytInitialData but could not parse it as JSON: {exc}")
 
-    out = Path("/tmp/yt_data.json")
+    out = Path(f"/tmp/yt_data_{tab}.json")
     out.write_text(json.dumps(data, indent=2))
     print(f"ytInitialData written to {out}  ({out.stat().st_size:,} bytes)")
 


### PR DESCRIPTION
- dump_channel_html.py now accepts an optional second positional arg (tab: videos|streams, default videos); URL and output filename (/tmp/yt_data_<tab>.json) both use the selected tab so streams can be inspected directly without editing the script
- discover_videos() warning now appends the tab name to the suggested command, e.g. "python3 helpers/dump_channel_html.py UCxxx streams"
- CLAUDE.md updated

https://claude.ai/code/session_01ScArKBEbSqhuf5L8G9SCCA