### PR TITLE
Suppress false-positive warning when streams tab shows playlist cards

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -456,6 +456,15 @@ def discover_videos(channel_id: str, feed_name: str = "") -> list[VideoInfo]:
                 "video IDs — YouTube HTML structure may have changed."
             )
         elif not tab_meta:
+            if '"collectionThumbnailViewModel"' in html:
+                # Tab is showing playlist cards rather than individual videos
+                # (some channels organise streams this way). The regex finds
+                # false-positive IDs from playlist thumbnail URLs — skip them.
+                logger.debug(
+                    f"{prefix}YouTube: {tab} tab shows playlist cards, not "
+                    "individual videos — skipping."
+                )
+                continue
             logger.warning(
                 f"{prefix}YouTube: Found {len(found)} video ID(s) on {tab} tab "
                 "but could not parse any titles or dates — "


### PR DESCRIPTION
Some channels (e.g. Watsonville) show their streams organised as playlist cards (lockupViewModel + collectionThumbnailViewModel) rather than as individual videoRenderer entries. The videoId regex was finding IDs embedded in playlist thumbnail URLs and triggering the "could not parse titles or dates" warning even though the parser was working correctly.

When tab_meta is empty but collectionThumbnailViewModel is present, skip the tab with a debug log instead of a warning, and don't add the false-positive IDs to all_ids. The warning still fires for genuine structural breakage where neither condition holds.

https://claude.ai/code/session_01ScArKBEbSqhuf5L8G9SCCA