### PR TITLE
Fix mark-all-read/unread ignoring channel filter context

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -2030,6 +2030,84 @@ def test_mark_all_unread_clears_read_articles_and_redirects(logged_in_client, ar
         assert data.get("read_articles") == []
 
 
+def test_mark_all_read_with_channel_id_only_marks_that_channel(
+        logged_in_client, archive, monkeypatch):
+    """POST /account/mark-all-read with channel_id must only mark stories from
+    that channel, not stories from other channels the user subscribes to."""
+    import json as _json
+    import TubeNews as _tn
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+
+    user_dir = archive / "_users"
+    # Subscribe the user to both channels.
+    for user_json in user_dir.glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        data["channels"] = {"UC_ALPHA_ID": [], "UC_BETA__ID": []}
+        data["read_articles"] = []
+        user_json.write_text(_json.dumps(data))
+
+    # Get the content hash for the Beta story so we can verify it stays unread.
+    beta_story = archive / "beta_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    beta_hash = _tn.parse_story_file(beta_story)["content_hash"]
+
+    r = logged_in_client.post(
+        "/account/mark-all-read",
+        data={"channel_id": "UC_ALPHA_ID"},
+    )
+    assert r.status_code == 302
+    assert "channel=UC_ALPHA_ID" in r.headers["Location"]
+
+    for user_json in user_dir.glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        read = set(data.get("read_articles", []))
+        # Beta story must NOT be in read_articles.
+        assert beta_hash not in read, "mark-all-read with channel_id marked another channel's story"
+        # At least one hash should have been added (the Alpha story).
+        assert len(read) >= 1
+
+
+def test_mark_all_unread_with_channel_id_only_clears_that_channel(
+        logged_in_client, archive, monkeypatch):
+    """POST /account/mark-all-unread with channel_id must only unmark stories
+    from that channel, leaving other channels' stories marked as read."""
+    import json as _json
+    import TubeNews as _tn
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+
+    user_dir = archive / "_users"
+
+    alpha_story = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    beta_story  = archive / "beta_city"  / "2026-01-15_VID12345678" / "01_Story.md"
+    alpha_hash = _tn.parse_story_file(alpha_story)["content_hash"]
+    beta_hash  = _tn.parse_story_file(beta_story)["content_hash"]
+
+    # Subscribe the user to both channels and pre-mark both stories as read.
+    for user_json in user_dir.glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        data["channels"] = {"UC_ALPHA_ID": [], "UC_BETA__ID": []}
+        data["read_articles"] = sorted({alpha_hash, beta_hash})
+        user_json.write_text(_json.dumps(data))
+
+    r = logged_in_client.post(
+        "/account/mark-all-unread",
+        data={"channel_id": "UC_ALPHA_ID"},
+    )
+    assert r.status_code == 302
+    assert "channel=UC_ALPHA_ID" in r.headers["Location"]
+
+    for user_json in user_dir.glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        read = set(data.get("read_articles", []))
+        assert alpha_hash not in read, "mark-all-unread with channel_id should have removed alpha hash"
+        assert beta_hash in read, "mark-all-unread with channel_id must not touch other channel's hash"
+
+
 def test_serve_read_requires_login(client, archive):
     """/read must redirect unauthenticated requests to login."""
     r = client.get("/read")

--- a/web/app.py
+++ b/web/app.py
@@ -1170,8 +1170,15 @@ def account_mark_unread():
 @app.route("/account/mark-all-read", methods=["POST"])
 @login_required
 def account_mark_all_read():
-    """Mark all of the user's current stories as read, then redirect to /blog."""
+    """Mark all of the user's current stories as read, then redirect to /blog.
+
+    If a ``channel_id`` form field is present, only stories from that channel
+    are marked; the redirect preserves the ``?channel=`` filter.
+    """
+    channel_id = request.form.get("channel_id", "").strip()
     all_stories = _get_user_stories(current_user._data, current_user.get_id())
+    if channel_id:
+        all_stories = [s for s in all_stories if s.get("channel_id") == channel_id]
     read_set = set(current_user._data.get("read_articles", []))
     for s in all_stories:
         h = s.get("content_hash", "")
@@ -1179,15 +1186,34 @@ def account_mark_all_read():
             read_set.add(h)
     current_user._data["read_articles"] = sorted(read_set)
     current_user._save()
+    if channel_id:
+        return redirect(url_for("serve_blog") + f"?channel={channel_id}")
     return redirect(url_for("serve_blog"))
 
 
 @app.route("/account/mark-all-unread", methods=["POST"])
 @login_required
 def account_mark_all_unread():
-    """Clear all read articles, then redirect to the inbox."""
-    current_user._data["read_articles"] = []
+    """Clear all read articles, then redirect to the inbox.
+
+    If a ``channel_id`` form field is present, only stories from that channel
+    are unmarked; the redirect preserves the ``?channel=`` filter.
+    """
+    channel_id = request.form.get("channel_id", "").strip()
+    if channel_id:
+        channel_hashes = {
+            s["content_hash"]
+            for s in _get_user_stories(current_user._data, current_user.get_id())
+            if s.get("channel_id") == channel_id and s.get("content_hash")
+        }
+        read_set = set(current_user._data.get("read_articles", []))
+        read_set -= channel_hashes
+        current_user._data["read_articles"] = sorted(read_set)
+    else:
+        current_user._data["read_articles"] = []
     current_user._save()
+    if channel_id:
+        return redirect(url_for("serve_blog") + f"?channel={channel_id}")
     return redirect(url_for("serve_blog"))
 
 

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -26,12 +26,18 @@
       {% if not is_archive %}
       <form method="post" action="{{ url_for('account_mark_all_read') }}" style="display:contents">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {% if active_channel_id is defined and active_channel_id %}
+        <input type="hidden" name="channel_id" value="{{ active_channel_id }}">
+        {% endif %}
         <button type="submit" class="btn-sm">Mark All Read</button>
       </form>
       {% endif %}
       {% if is_archive or is_all %}
       <form method="post" action="{{ url_for('account_mark_all_unread') }}" style="display:contents">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {% if active_channel_id is defined and active_channel_id %}
+        <input type="hidden" name="channel_id" value="{{ active_channel_id }}">
+        {% endif %}
         <button type="submit" class="btn-sm">Mark All Unread</button>
       </form>
       {% endif %}


### PR DESCRIPTION
When viewing /blog?channel=UCxxx via the sidebar, the bulk action buttons now scope to the selected channel: only that channel's stories are marked/unmarked, and the redirect preserves the ?channel= param.

Both routes accept an optional channel_id form field (injected by a hidden input in the template when active_channel_id is set). Without the field the behaviour is unchanged (all stories, redirect to /blog).

Added regression tests for the channel-scoped variants of both routes.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN