### PR TITLE
Sidebar polish: visited color, All Channels header, feed name prominence

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -98,7 +98,7 @@ header {
 .header-sub a:hover { text-decoration: underline; }
 /* Left: feed name + nav tabs */
 .hs-left { flex: 1; display: flex; align-items: center; gap: 0.75rem; min-width: 0; }
-.hs-feed-name { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hs-feed-name { font-size: 1.05rem; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-right: 1px solid var(--border); padding-right: 0.75rem; margin-right: 0.25rem; }
 .hs-tab { font-weight: 400; color: var(--muted); padding: 0 0.1rem; border-bottom: 2px solid transparent; line-height: 36px; }
 .hs-tab:hover { color: var(--text); text-decoration: none; }
 .hs-tab-active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 500; }
@@ -675,11 +675,19 @@ main:has(.blog-layout) {
   gap: 0.4rem;
 }
 
+.sidebar-channel:visited { color: var(--text); }
 .sidebar-channel:hover { background: var(--border); }
 
 .sc-active {
   background: var(--border);
   font-weight: 600;
+}
+
+.sc-all {
+  font-weight: 700;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0.35rem;
+  padding-bottom: 0.35rem;
 }
 
 .sc-name {

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -65,8 +65,13 @@
 <div class="blog-layout">
 {% if channel_counts is defined and channel_counts and not channel_id %}
 <aside class="channel-sidebar" id="channel-sidebar">
-  <a class="sidebar-channel{% if not active_channel_id %} sc-active{% endif %}"
-     href="{{ current_view_url }}">All channels</a>
+  {% set total = channel_counts | sum(attribute='count') %}
+  <a class="sidebar-channel sc-all{% if not active_channel_id %} sc-active{% endif %}"
+     href="{{ current_view_url }}">
+    <span class="sc-name">All Channels</span>
+    <span class="sc-count">{{ total }}</span>
+  </a>
+  {# space reserved here for future channel bundles #}
   {% for ch in channel_counts %}
   <a class="sidebar-channel{% if active_channel_id == ch.channel_id %} sc-active{% endif %}"
      href="{{ current_view_url }}?channel={{ ch.channel_id }}"


### PR DESCRIPTION
- sidebar-channel:visited keeps var(--text) so visited links don't turn blue
- "All channels" → "All Channels" with total count badge (.sc-all) and a bottom border separating it from individual channel rows; bundle section placeholder comment added between the two groups for future use
- .hs-feed-name gets font-size: 1.05rem, color: var(--text), and a right border separator so the page title reads distinctly from the nav tabs

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN