### PR TITLE
Add user-created channel bundles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,7 +409,8 @@ content/_users/
   "preferences": {"dark_mode": false, "font_size": "normal"},
   "seen_channel_ids": ["UCxxxxxxx", "UCyyyyyyy"],
   "read_articles": ["abc123hash", "def456hash"],
-  "starred_articles": ["abc123hash"]
+  "starred_articles": ["abc123hash"],
+  "bundles": [{"name": "City Government", "channel_ids": ["UCxxxxxxx", "UCyyyyyyy"]}]
 }
 ```
 
@@ -422,6 +423,7 @@ content/_users/
 - `seen_channel_ids` — list of channel IDs the user has "seen" on the dashboard. The `inject_body_classes` context processor diffs this against the current feed list to compute `unseen_channel_count`, which drives the red badge on the "Settings" nav link. Key absent means not yet initialised (pre-feature users); treated as 0 unseen so existing users aren't badged on upgrade. Written (covering all current channels) whenever the user loads or saves the dashboard.
 - `read_articles` — sorted list of `content_hash` strings for articles the user has marked as read. `/blog` (Unread tab) hides stories whose hash is in this list; `/read` (Read tab) shows only those stories. Key absent means no articles have been read. Written by the `account_mark_read`, `account_mark_unread`, `account_mark_all_read`, and `account_mark_all_unread` routes. Growth is bounded (~117 KB/year at 10 stories/day × 32 bytes/hash) and individual unread is preserved.
 - `starred_articles` — sorted list of `content_hash` strings for articles the user has starred. `/starred` shows only these stories. Key absent means no starred articles. Written by the `account_mark_starred` and `account_mark_unstarred` routes. Independent of read/unread state.
+- `bundles` — list of `{name: str, channel_ids: [str]}` dicts defining user-created channel bundles. Bundles appear in the sidebar between "All Channels" and the individual channel list. Clicking a bundle filters the view to stories from those channels via `?bundle=<slug>`. The slug is `slugify(name).lower()`, computed at runtime. Key absent means no bundles. Written by `POST /account/bundles`.
 
 ### Token Model
 
@@ -486,6 +488,8 @@ the web app does **not** call either — the web UI uses dynamic generation only
 | `_get_channel_stories(channel_id)` | Returns `(channel_name | None, list[StoryDict])` for a single channel. Used by `channel_blog`. |
 | `_get_user_stories(user_data, user_id)` | Scans all subscribed channel directories and returns `list[StoryDict]` filtered by the user's `user_ids` attribution. Used by `serve_blog`, `serve_read`, `serve_all`, and the public blog route. |
 | `_channel_counts(stories)` | Takes a `list[StoryDict]` and returns `list[dict]` with `channel_id`, `channel_name`, and `count` keys, sorted by count descending. Used by all four blog routes to populate the channel sidebar. |
+| `_user_bundles(user_data)` | Returns the user's `bundles` list with a `slug` field added to each entry (`slugify(name).lower()`). Returns `[]` when `bundles` key is absent. |
+| `_bundle_counts(stories, bundles)` | Annotates each bundle dict with a `count` of matching stories from *stories*. Used by all four blog routes to populate bundle sidebar entries. |
 | `_get_supadata_balance()` | Reads the cached Supadata credit data from `content/_run_logs/supadata_balance.json`; returns `None` if absent. Used by `admin_feeds` to show the credit balance without a live API call. |
 
 ### Route Map
@@ -521,6 +525,7 @@ the web app does **not** call either — the web UI uses dynamic generation only
 | POST | `/account/mark-unread` | `account_mark_unread` | Remove a `content_hash` from `read_articles`; returns JSON `{"ok": true}` |
 | POST | `/account/mark-all-read` | `account_mark_all_read` | Mark all current stories as read; redirects to `/blog` |
 | POST | `/account/mark-all-unread` | `account_mark_all_unread` | Clear all read articles (mark everything unread); redirects to `/blog` |
+| POST | `/account/bundles` | `account_bundles` | Save user-defined channel bundles (list of `{name, channel_ids}` parsed from indexed form fields); key absent or empty name = delete bundle |
 | POST | `/account/mark-starred` | `account_mark_starred` | Add a `content_hash` to the user's `starred_articles`; returns JSON `{"ok": true}` |
 | POST | `/account/mark-unstarred` | `account_mark_unstarred` | Remove a `content_hash` from `starred_articles`; returns JSON `{"ok": true}` |
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -2699,3 +2699,162 @@ def test_serve_starred_channel_filter(client, archive, monkeypatch):
     assert r.status_code == 200
     assert b"Alpha Council Approves Budget" in r.data
     assert b"Beta Council Discusses Zoning" not in r.data
+
+# ---------------------------------------------------------------------------
+# Channel bundles
+# ---------------------------------------------------------------------------
+
+def test_account_bundles_save(logged_in_client, archive, monkeypatch):
+    """POST /account/bundles must save bundles to user.json."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        data["channels"] = {"UC_ALPHA_ID": []}
+        user_json.write_text(_json.dumps(data))
+
+    r = logged_in_client.post("/account/bundles", data={
+        "bundle_count": "0",
+        "new_bundle_name": "My Bundle",
+        "new_bundle_channels": "UC_ALPHA_ID",
+    })
+    assert r.status_code == 302
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        bundles = data.get("bundles", [])
+        assert len(bundles) == 1
+        assert bundles[0]["name"] == "My Bundle"
+        assert "UC_ALPHA_ID" in bundles[0]["channel_ids"]
+
+
+def test_account_bundles_clear_name_deletes_bundle(logged_in_client, archive, monkeypatch):
+    """Saving a bundle with an empty name must delete it."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        data["channels"] = {"UC_ALPHA_ID": []}
+        data["bundles"] = [{"name": "To Delete", "channel_ids": ["UC_ALPHA_ID"]}]
+        user_json.write_text(_json.dumps(data))
+
+    # Send bundle_name_0 as empty string to delete it
+    r = logged_in_client.post("/account/bundles", data={
+        "bundle_count": "1",
+        "bundle_name_0": "",
+        "bundle_channels_0": "UC_ALPHA_ID",
+    })
+    assert r.status_code == 302
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        assert data.get("bundles", []) == []
+
+
+def test_serve_blog_bundle_filter(logged_in_client, archive, monkeypatch):
+    """GET /blog?bundle=<slug> must show only stories from channels in that bundle."""
+    import json as _json
+    import web.app as _wa
+    import TubeNews as _tn
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        data["channels"] = {"UC_ALPHA_ID": [], "UC_BETA__ID": []}
+        data["bundles"] = [{"name": "Alpha Only", "channel_ids": ["UC_ALPHA_ID"]}]
+        data["read_articles"] = []
+        user_json.write_text(_json.dumps(data))
+
+    r = logged_in_client.get("/blog?bundle=alpha_only")
+    assert r.status_code == 200
+    assert b"Alpha Council Approves Budget" in r.data
+    assert b"Beta Council Discusses Zoning" not in r.data
+
+
+def test_serve_blog_unknown_bundle_returns_404(logged_in_client, archive, monkeypatch):
+    """GET /blog?bundle=<nonexistent> must return 404."""
+    import json as _json
+    import web.app as _wa
+    import TubeNews as _tn
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        data["channels"] = {"UC_ALPHA_ID": []}
+        data["read_articles"] = []
+        user_json.write_text(_json.dumps(data))
+
+    r = logged_in_client.get("/blog?bundle=no_such_bundle")
+    assert r.status_code == 404
+
+
+def test_mark_all_read_with_bundle_slug(logged_in_client, archive, monkeypatch):
+    """POST /account/mark-all-read with bundle_slug marks only that bundle's channels."""
+    import json as _json
+    import web.app as _wa
+    import TubeNews as _tn
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+
+    beta_story = archive / "beta_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    beta_hash = _tn.parse_story_file(beta_story)["content_hash"]
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        data["channels"] = {"UC_ALPHA_ID": [], "UC_BETA__ID": []}
+        data["bundles"] = [{"name": "Alpha Only", "channel_ids": ["UC_ALPHA_ID"]}]
+        data["read_articles"] = []
+        user_json.write_text(_json.dumps(data))
+
+    r = logged_in_client.post("/account/mark-all-read", data={"bundle_slug": "alpha_only"})
+    assert r.status_code == 302
+    assert "bundle=alpha_only" in r.headers["Location"]
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        read = set(data.get("read_articles", []))
+        assert beta_hash not in read, "bundle mark-all-read must not touch other channels"
+        assert len(read) >= 1
+
+
+def test_mark_all_unread_with_bundle_slug(logged_in_client, archive, monkeypatch):
+    """POST /account/mark-all-unread with bundle_slug unmarks only that bundle's channels."""
+    import json as _json
+    import web.app as _wa
+    import TubeNews as _tn
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_tn, "STORAGE_ROOT", archive)
+
+    alpha_story = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story.md"
+    beta_story  = archive / "beta_city"  / "2026-01-15_VID12345678" / "01_Story.md"
+    alpha_hash = _tn.parse_story_file(alpha_story)["content_hash"]
+    beta_hash  = _tn.parse_story_file(beta_story)["content_hash"]
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        data["channels"] = {"UC_ALPHA_ID": [], "UC_BETA__ID": []}
+        data["bundles"] = [{"name": "Alpha Only", "channel_ids": ["UC_ALPHA_ID"]}]
+        data["read_articles"] = sorted({alpha_hash, beta_hash})
+        user_json.write_text(_json.dumps(data))
+
+    r = logged_in_client.post("/account/mark-all-unread", data={"bundle_slug": "alpha_only"})
+    assert r.status_code == 302
+    assert "bundle=alpha_only" in r.headers["Location"]
+
+    for user_json in (archive / "_users").glob("*/user.json"):
+        data = _json.loads(user_json.read_text())
+        read = set(data.get("read_articles", []))
+        assert alpha_hash not in read, "bundle mark-all-unread should have removed alpha hash"
+        assert beta_hash in read, "bundle mark-all-unread must not touch other channels"

--- a/web/app.py
+++ b/web/app.py
@@ -555,6 +555,25 @@ def _channel_counts(stories: list[StoryDict]) -> list[dict]:
     return sorted(mapping.values(), key=lambda c: c["channel_name"].lower())
 
 
+def _user_bundles(user_data: dict) -> list[dict]:
+    """Return the user's bundles with a 'slug' field added (computed from name, lowercased)."""
+    return [
+        {"name": b["name"], "slug": slugify(b["name"]).lower(), "channel_ids": b.get("channel_ids", [])}
+        for b in user_data.get("bundles", [])
+        if b.get("name", "").strip()
+    ]
+
+
+def _bundle_counts(stories: list[StoryDict], bundles: list[dict]) -> list[dict]:
+    """Add a 'count' of matching stories to each bundle dict."""
+    result = []
+    for b in bundles:
+        cids = set(b["channel_ids"])
+        count = sum(1 for s in stories if s["channel_id"] in cids)
+        result.append({**b, "count": count})
+    return result
+
+
 def _get_channel_stories(channel_id: str) -> tuple[str | None, list[StoryDict]]:
     """Return (channel_name, stories) for a single channel, newest-first.
 
@@ -899,8 +918,16 @@ def serve_blog():
     starred_hashes = set(current_user._data.get("starred_articles", []))
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
     counts = _channel_counts(stories)
-    active_channel_id = request.args.get("channel", "")
-    if active_channel_id:
+    user_bundles = _user_bundles(current_user._data)
+    bundle_counts = _bundle_counts(stories, user_bundles)
+    active_bundle_slug = request.args.get("bundle", "")
+    active_channel_id = "" if active_bundle_slug else request.args.get("channel", "")
+    if active_bundle_slug:
+        bundle_cids = next((set(b["channel_ids"]) for b in user_bundles if b["slug"] == active_bundle_slug), None)
+        if bundle_cids is None:
+            abort(404)
+        stories = [s for s in stories if s["channel_id"] in bundle_cids]
+    elif active_channel_id:
         if not any(s["channel_id"] == active_channel_id for s in stories):
             abort(404)
         stories = [s for s in stories if s["channel_id"] == active_channel_id]
@@ -908,6 +935,7 @@ def serve_blog():
                            feed_path=f"/feed/{current_user.feed_token}.xml",
                            read_count=read_count, starred_hashes=starred_hashes,
                            channel_counts=counts, active_channel_id=active_channel_id,
+                           bundles=bundle_counts, active_bundle_slug=active_bundle_slug,
                            current_view_url=url_for("serve_blog"))
 
 
@@ -923,8 +951,16 @@ def serve_read():
     starred_hashes = set(current_user._data.get("starred_articles", []))
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
     counts = _channel_counts(stories)
-    active_channel_id = request.args.get("channel", "")
-    if active_channel_id:
+    user_bundles = _user_bundles(current_user._data)
+    bundle_counts = _bundle_counts(stories, user_bundles)
+    active_bundle_slug = request.args.get("bundle", "")
+    active_channel_id = "" if active_bundle_slug else request.args.get("channel", "")
+    if active_bundle_slug:
+        bundle_cids = next((set(b["channel_ids"]) for b in user_bundles if b["slug"] == active_bundle_slug), None)
+        if bundle_cids is None:
+            abort(404)
+        stories = [s for s in stories if s["channel_id"] in bundle_cids]
+    elif active_channel_id:
         if not any(s["channel_id"] == active_channel_id for s in stories):
             abort(404)
         stories = [s for s in stories if s["channel_id"] == active_channel_id]
@@ -932,6 +968,7 @@ def serve_read():
                            feed_path=f"/feed/{current_user.feed_token}.xml",
                            is_archive=True, starred_hashes=starred_hashes,
                            channel_counts=counts, active_channel_id=active_channel_id,
+                           bundles=bundle_counts, active_bundle_slug=active_bundle_slug,
                            current_view_url=url_for("serve_read"))
 
 
@@ -953,8 +990,16 @@ def serve_all():
     starred_hashes = set(current_user._data.get("starred_articles", []))
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
     counts = _channel_counts(stories)
-    active_channel_id = request.args.get("channel", "")
-    if active_channel_id:
+    user_bundles = _user_bundles(current_user._data)
+    bundle_counts = _bundle_counts(stories, user_bundles)
+    active_bundle_slug = request.args.get("bundle", "")
+    active_channel_id = "" if active_bundle_slug else request.args.get("channel", "")
+    if active_bundle_slug:
+        bundle_cids = next((set(b["channel_ids"]) for b in user_bundles if b["slug"] == active_bundle_slug), None)
+        if bundle_cids is None:
+            abort(404)
+        stories = [s for s in stories if s["channel_id"] in bundle_cids]
+    elif active_channel_id:
         if not any(s["channel_id"] == active_channel_id for s in stories):
             abort(404)
         stories = [s for s in stories if s["channel_id"] == active_channel_id]
@@ -963,6 +1008,7 @@ def serve_all():
                            feed_path=f"/feed/{current_user.feed_token}.xml",
                            is_all=True, query=query, starred_hashes=starred_hashes,
                            channel_counts=counts, active_channel_id=active_channel_id,
+                           bundles=bundle_counts, active_bundle_slug=active_bundle_slug,
                            current_view_url=current_view)
 
 
@@ -977,8 +1023,16 @@ def serve_starred():
     stories = [s for s in all_stories if s.get("content_hash", "") in starred_set]
     blog_name = current_user._data.get("blog_name") or f"{current_user.name}'s TubeNews"
     counts = _channel_counts(stories)
-    active_channel_id = request.args.get("channel", "")
-    if active_channel_id:
+    user_bundles = _user_bundles(current_user._data)
+    bundle_counts = _bundle_counts(stories, user_bundles)
+    active_bundle_slug = request.args.get("bundle", "")
+    active_channel_id = "" if active_bundle_slug else request.args.get("channel", "")
+    if active_bundle_slug:
+        bundle_cids = next((set(b["channel_ids"]) for b in user_bundles if b["slug"] == active_bundle_slug), None)
+        if bundle_cids is None:
+            abort(404)
+        stories = [s for s in stories if s["channel_id"] in bundle_cids]
+    elif active_channel_id:
         if not any(s["channel_id"] == active_channel_id for s in stories):
             abort(404)
         stories = [s for s in stories if s["channel_id"] == active_channel_id]
@@ -986,6 +1040,7 @@ def serve_starred():
                            feed_path=f"/feed/{current_user.feed_token}.xml",
                            is_starred=True, starred_hashes=starred_set,
                            channel_counts=counts, active_channel_id=active_channel_id,
+                           bundles=bundle_counts, active_bundle_slug=active_bundle_slug,
                            current_view_url=url_for("serve_starred"))
 
 
@@ -1086,7 +1141,31 @@ def account():
         feed_url=_feed_url(current_user.feed_token),
         blog_url=_blog_url(current_user.feed_token) if current_user.channel_ids else None,
         prefs=prefs,
+        bundles=_user_bundles(current_user._data),
     )
+
+
+@app.route("/account/bundles", methods=["POST"])
+@login_required
+def account_bundles():
+    """Save the user's channel bundles from the account page form."""
+    bundle_count = int(request.form.get("bundle_count", "0") or "0")
+    valid_ids = set(current_user.channel_ids)
+    bundles: list[dict] = []
+    for i in range(min(bundle_count, 20)):
+        name = request.form.get(f"bundle_name_{i}", "").strip()[:100]
+        if not name:
+            continue  # empty name = delete this bundle
+        channel_ids = [cid for cid in request.form.getlist(f"bundle_channels_{i}") if cid in valid_ids]
+        bundles.append({"name": name, "channel_ids": channel_ids})
+    new_name = request.form.get("new_bundle_name", "").strip()[:100]
+    if new_name:
+        new_channels = [cid for cid in request.form.getlist("new_bundle_channels") if cid in valid_ids]
+        bundles.append({"name": new_name, "channel_ids": new_channels})
+    current_user._data["bundles"] = bundles
+    current_user._save()
+    flash("Bundles saved.", "success")
+    return redirect(url_for("account"))
 
 
 @app.route("/account/password", methods=["POST"])
@@ -1172,12 +1251,17 @@ def account_mark_unread():
 def account_mark_all_read():
     """Mark all of the user's current stories as read, then redirect to /blog.
 
-    If a ``channel_id`` form field is present, only stories from that channel
-    are marked; the redirect preserves the ``?channel=`` filter.
+    If a ``bundle_slug`` form field is present, only stories from that bundle's
+    channels are marked.  If a ``channel_id`` form field is present, only
+    stories from that channel are marked.  The redirect preserves the filter.
     """
+    bundle_slug = request.form.get("bundle_slug", "").strip()
     channel_id = request.form.get("channel_id", "").strip()
     all_stories = _get_user_stories(current_user._data, current_user.get_id())
-    if channel_id:
+    if bundle_slug:
+        bundle_cids = next((set(b["channel_ids"]) for b in _user_bundles(current_user._data) if b["slug"] == bundle_slug), set())
+        all_stories = [s for s in all_stories if s.get("channel_id") in bundle_cids]
+    elif channel_id:
         all_stories = [s for s in all_stories if s.get("channel_id") == channel_id]
     read_set = set(current_user._data.get("read_articles", []))
     for s in all_stories:
@@ -1186,6 +1270,8 @@ def account_mark_all_read():
             read_set.add(h)
     current_user._data["read_articles"] = sorted(read_set)
     current_user._save()
+    if bundle_slug:
+        return redirect(url_for("serve_blog") + f"?bundle={bundle_slug}")
     if channel_id:
         return redirect(url_for("serve_blog") + f"?channel={channel_id}")
     return redirect(url_for("serve_blog"))
@@ -1196,11 +1282,23 @@ def account_mark_all_read():
 def account_mark_all_unread():
     """Clear all read articles, then redirect to the inbox.
 
-    If a ``channel_id`` form field is present, only stories from that channel
-    are unmarked; the redirect preserves the ``?channel=`` filter.
+    If a ``bundle_slug`` form field is present, only stories from that bundle's
+    channels are unmarked.  If a ``channel_id`` form field is present, only
+    stories from that channel are unmarked.  The redirect preserves the filter.
     """
+    bundle_slug = request.form.get("bundle_slug", "").strip()
     channel_id = request.form.get("channel_id", "").strip()
-    if channel_id:
+    if bundle_slug:
+        bundle_cids = next((set(b["channel_ids"]) for b in _user_bundles(current_user._data) if b["slug"] == bundle_slug), set())
+        bundle_hashes = {
+            s["content_hash"]
+            for s in _get_user_stories(current_user._data, current_user.get_id())
+            if s.get("channel_id") in bundle_cids and s.get("content_hash")
+        }
+        read_set = set(current_user._data.get("read_articles", []))
+        read_set -= bundle_hashes
+        current_user._data["read_articles"] = sorted(read_set)
+    elif channel_id:
         channel_hashes = {
             s["content_hash"]
             for s in _get_user_stories(current_user._data, current_user.get_id())
@@ -1212,6 +1310,8 @@ def account_mark_all_unread():
     else:
         current_user._data["read_articles"] = []
     current_user._save()
+    if bundle_slug:
+        return redirect(url_for("serve_blog") + f"?bundle={bundle_slug}")
     if channel_id:
         return redirect(url_for("serve_blog") + f"?channel={channel_id}")
     return redirect(url_for("serve_blog"))

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -446,6 +446,46 @@ button[type="submit"]:hover,
 }
 .channel-browse:hover { text-decoration: underline; }
 
+.bundle-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.bundle-row:last-of-type { border-bottom: none; }
+
+.bundle-name-input {
+  font-size: 0.9rem;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface, var(--bg));
+  color: var(--text);
+  width: 100%;
+  max-width: 24rem;
+  box-sizing: border-box;
+}
+
+.bundle-channels-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  padding-left: 0.25rem;
+}
+
+.bundle-ch-label {
+  font-size: 0.85rem;
+}
+
+.bundle-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
 .muted { color: var(--muted); font-size: 0.9rem; }
 .mono  { font-family: monospace; font-size: 0.875rem; }
 
@@ -688,6 +728,16 @@ main:has(.blog-layout) {
   border-bottom: 1px solid var(--border);
   margin-bottom: 0.35rem;
   padding-bottom: 0.35rem;
+}
+
+.sc-bundles {
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0.35rem;
+  padding-bottom: 0.35rem;
+}
+
+.sc-bundle .sc-name {
+  font-style: italic;
 }
 
 .sc-name {

--- a/web/templates/account.html
+++ b/web/templates/account.html
@@ -87,6 +87,56 @@
     {% endif %}
   </section>
 
+  <!-- ── Bundles ──────────────────────────────────────────── -->
+  {% if current_user.channel_ids %}
+  <section class="admin-section">
+    <h2>Channel Bundles</h2>
+    <p class="muted">Group subscribed channels into named bundles for quick sidebar filtering.</p>
+    <form method="post" action="{{ url_for('account_bundles') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="bundle_count" value="{{ bundles|length }}">
+
+      {% for bundle in bundles %}
+      {% set bi = loop.index0 %}
+      <div class="bundle-row">
+        <input type="text" class="bundle-name-input" name="bundle_name_{{ bi }}"
+               value="{{ bundle.name }}"
+               placeholder="Bundle name (clear to delete)">
+        <div class="bundle-channels-row">
+          {% for ch in channels %}{% if ch.channel_id in subscribed %}
+          <label class="checkbox-label bundle-ch-label">
+            <input type="checkbox" name="bundle_channels_{{ bi }}" value="{{ ch.channel_id }}"
+                   {% if ch.channel_id in bundle.channel_ids %}checked{% endif %}>
+            {{ ch.channel_name }}
+          </label>
+          {% endif %}{% endfor %}
+        </div>
+      </div>
+      {% else %}
+      <p class="muted" id="no-bundles-msg">No bundles yet.</p>
+      {% endfor %}
+
+      <div class="bundle-row" id="new-bundle-row" style="display:none">
+        <input type="text" class="bundle-name-input" name="new_bundle_name"
+               id="new-bundle-name" placeholder="New bundle name">
+        <div class="bundle-channels-row">
+          {% for ch in channels %}{% if ch.channel_id in subscribed %}
+          <label class="checkbox-label bundle-ch-label">
+            <input type="checkbox" name="new_bundle_channels" value="{{ ch.channel_id }}">
+            {{ ch.channel_name }}
+          </label>
+          {% endif %}{% endfor %}
+        </div>
+      </div>
+
+      <div class="bundle-actions">
+        <button type="button" id="add-bundle-btn" class="btn-select-all">+ Add bundle</button>
+        <button type="submit" class="btn-save">Save bundles</button>
+      </div>
+    </form>
+  </section>
+  {% endif %}
+
   <!-- ── Display ────────────────────────────────────────────── -->
   <section class="admin-section">
     <h2>Display</h2>
@@ -211,6 +261,14 @@
   });
   document.getElementById('btn-unselect-all')?.addEventListener('click', () => {
     checkboxes.forEach(cb => { cb.checked = false; updateFocusVisibility(cb); });
+  });
+
+  document.getElementById('add-bundle-btn')?.addEventListener('click', function() {
+    document.getElementById('new-bundle-row').style.display = '';
+    this.style.display = 'none';
+    document.getElementById('new-bundle-name').focus();
+    var msg = document.getElementById('no-bundles-msg');
+    if (msg) msg.style.display = 'none';
   });
 
   function copyUrl(inputId, btn) {

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -9,7 +9,7 @@
     {% endif %}
     <span class="hs-feed-name">{{ blog_name }}</span>
     {% if current_user.is_authenticated and not channel_id %}
-      {% set _ch = ('?channel=' ~ active_channel_id) if active_channel_id is defined and active_channel_id else '' %}
+      {% set _ch = ('?bundle=' ~ active_bundle_slug) if active_bundle_slug is defined and active_bundle_slug else (('?channel=' ~ active_channel_id) if active_channel_id is defined and active_channel_id else '') %}
       <a class="hs-tab{% if not is_archive and not is_all and not is_starred %} hs-tab-active{% endif %}" href="{{ url_for('serve_blog') }}{{ _ch }}">Unread{% if not is_archive and not is_all and not is_starred %}<span class="tab-count" id="unread-badge"{% if not stories %} style="display:none"{% endif %}>{{ stories|length }}</span>{% endif %}</a>
       <a class="hs-tab{% if is_starred %} hs-tab-active{% endif %}" href="{{ url_for('serve_starred') }}{{ _ch }}">Starred<span class="tab-count" id="starred-badge"{% if not starred_hashes %} style="display:none"{% endif %}>{{ starred_hashes|length }}</span></a>
       <a class="hs-tab{% if is_archive %} hs-tab-active{% endif %}" href="{{ url_for('serve_read') }}{{ _ch }}">Read</a>
@@ -26,7 +26,9 @@
       {% if not is_archive %}
       <form method="post" action="{{ url_for('account_mark_all_read') }}" style="display:contents">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        {% if active_channel_id is defined and active_channel_id %}
+        {% if active_bundle_slug is defined and active_bundle_slug %}
+        <input type="hidden" name="bundle_slug" value="{{ active_bundle_slug }}">
+        {% elif active_channel_id is defined and active_channel_id %}
         <input type="hidden" name="channel_id" value="{{ active_channel_id }}">
         {% endif %}
         <button type="submit" class="btn-sm">Mark All Read</button>
@@ -35,7 +37,9 @@
       {% if is_archive or is_all %}
       <form method="post" action="{{ url_for('account_mark_all_unread') }}" style="display:contents">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        {% if active_channel_id is defined and active_channel_id %}
+        {% if active_bundle_slug is defined and active_bundle_slug %}
+        <input type="hidden" name="bundle_slug" value="{{ active_bundle_slug }}">
+        {% elif active_channel_id is defined and active_channel_id %}
         <input type="hidden" name="channel_id" value="{{ active_channel_id }}">
         {% endif %}
         <button type="submit" class="btn-sm">Mark All Unread</button>
@@ -66,12 +70,23 @@
 {% if channel_counts is defined and channel_counts and not channel_id %}
 <aside class="channel-sidebar" id="channel-sidebar">
   {% set total = channel_counts | sum(attribute='count') %}
-  <a class="sidebar-channel sc-all{% if not active_channel_id %} sc-active{% endif %}"
+  {% set _any_filter = (active_channel_id is defined and active_channel_id) or (active_bundle_slug is defined and active_bundle_slug) %}
+  <a class="sidebar-channel sc-all{% if not _any_filter %} sc-active{% endif %}"
      href="{{ current_view_url }}">
     <span class="sc-name">All Channels</span>
     <span class="sc-count">{{ total }}</span>
   </a>
-  {# space reserved here for future channel bundles #}
+  {% if bundles is defined and bundles %}
+  <div class="sc-bundles">
+    {% for bundle in bundles %}
+    <a class="sidebar-channel sc-bundle{% if active_bundle_slug is defined and active_bundle_slug == bundle.slug %} sc-active{% endif %}"
+       href="{{ current_view_url }}?bundle={{ bundle.slug }}">
+      <span class="sc-name">{{ bundle.name }}</span>
+      <span class="sc-count">{{ bundle.count }}</span>
+    </a>
+    {% endfor %}
+  </div>
+  {% endif %}
   {% for ch in channel_counts %}
   <a class="sidebar-channel{% if active_channel_id == ch.channel_id %} sc-active{% endif %}"
      href="{{ current_view_url }}?channel={{ ch.channel_id }}"


### PR DESCRIPTION
Users can group subscribed channels into named bundles from the account page. Bundles appear in the sidebar between "All Channels" and individual channels, and filter all four blog views (/blog, /read, /starred, /all) via ?bundle=<slug>. Mark All Read/Unread honour bundle scope the same way they honour channel scope.

Storage: `bundles: [{name, channel_ids}]` in user.json. Slug is slugify(name).lower(), computed at runtime, never stored.

New helpers: _user_bundles(), _bundle_counts().
New route: POST /account/bundles.
6 new tests covering save, delete-by-empty-name, filter, 404, and mark-all-read/unread scoping.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN