### PR TITLE
Show Channel Bundles section whenever channels are configured

### DIFF
--- a/web/templates/account.html
+++ b/web/templates/account.html
@@ -88,10 +88,13 @@
   </section>
 
   <!-- ── Bundles ──────────────────────────────────────────── -->
-  {% if current_user.channel_ids %}
+  {% if channels %}
   <section class="admin-section">
     <h2>Channel Bundles</h2>
     <p class="muted">Group subscribed channels into named bundles for quick sidebar filtering.</p>
+    {% if not current_user.channel_ids %}
+    <p class="muted">Subscribe to channels above first, then come back to create bundles.</p>
+    {% else %}
     <form method="post" action="{{ url_for('account_bundles') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <input type="hidden" name="bundle_count" value="{{ bundles|length }}">
@@ -134,6 +137,7 @@
         <button type="submit" class="btn-save">Save bundles</button>
       </div>
     </form>
+    {% endif %}
   </section>
   {% endif %}
 


### PR DESCRIPTION
Previously the section was hidden until the user was subscribed to at least one channel, making it invisible on a fresh account. Now it appears whenever channels exist in TubeNews.json, with a prompt to subscribe first if no subscriptions are active yet.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN