### PR TITLE
Fix nav profile link always pointing to /account for all users

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -20,7 +20,7 @@
         {% endif %}
         <a href="{{ url_for('serve_blog') }}">Blog</a>
         {% block nav_extra %}{% endblock %}
-        <a href="{{ url_for('admin_user', uid=current_user.get_id()) if current_user.is_admin else url_for('account') }}" class="nav-profile">
+        <a href="{{ url_for('account') }}" class="nav-profile">
           <svg class="nav-profile-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
             <circle cx="12" cy="8" r="4"/>
             <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>


### PR DESCRIPTION
Admin users were routed to /admin/user/<uid> by the nav profile link, bypassing the account page and its bundle management section. Now all users go to /account; admins can still reach their admin user detail via the Admin panel.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN