### PR TITLE
TubeNews.py writes its own run log file; cron runs now appear in web UI

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -128,6 +128,23 @@ def setup_logging(debug_mode: bool) -> None:
     )
 
 
+def _add_run_log_file_handler() -> None:
+    """Add a FileHandler writing to content/_run_logs/run-<pid>.log.
+
+    Called after the lock is acquired so only actual runs produce a log file.
+    The file is the same one the web UI's admin_run_log view reads, so both
+    web-UI-triggered runs and cron runs appear identically in the Runs page.
+    """
+    log_dir = STORAGE_ROOT / "_run_logs"
+    log_dir.mkdir(exist_ok=True)
+    log_path = log_dir / f"run-{os.getpid()}.log"
+    fh = logging.FileHandler(log_path, encoding="utf-8")
+    fh.setFormatter(logging.Formatter(
+        "%(asctime)s %(levelname)s: %(message)s", datefmt="%H:%M:%S"
+    ))
+    logging.getLogger().addHandler(fh)
+
+
 # ---------------------------------------------------------------------------
 # Data contracts (TypedDicts)
 # ---------------------------------------------------------------------------
@@ -1609,6 +1626,7 @@ def main() -> None:
         return
 
     try:
+        _add_run_log_file_handler()
         _main_body(args)
     finally:
         _release_lock()

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -756,8 +756,12 @@ def test_run_log_no_running_indicator_for_other_pid(admin_client, archive):
     assert b"Running" not in r.data
 
 
-def test_run_now_creates_log_in_run_logs_dir(admin_client, archive, monkeypatch):
-    """Run Now must write stdout/stderr into archive/_run_logs/run-{pid}.log."""
+def test_run_now_launches_process_without_stdout_redirect(admin_client, archive, monkeypatch):
+    """Run Now must start TubeNews.py without capturing stdout/stderr.
+
+    TubeNews.py writes its own run-<pid>.log via a FileHandler, so the web UI
+    no longer needs to redirect output.
+    """
     fake_pid = 55555
     mock_proc = MagicMock()
     mock_proc.pid = fake_pid
@@ -765,10 +769,9 @@ def test_run_now_creates_log_in_run_logs_dir(admin_client, archive, monkeypatch)
     monkeypatch.setattr(subprocess, "Popen", mock_popen)
     admin_client.post("/admin/run-now")
     _, kwargs = mock_popen.call_args
-    # stdout and stderr must be the same open file handle (not DEVNULL).
-    assert kwargs["stdout"] is kwargs["stderr"]
-    # The log file must now exist under _run_logs/ with the PID name.
-    assert (archive / "_run_logs" / f"run-{fake_pid}.log").exists()
+    # No stdout/stderr capture — TubeNews.py handles its own log file.
+    assert "stdout" not in kwargs
+    assert "stderr" not in kwargs
 
 
 def test_admin_runs_shows_log_link_for_run_with_log(admin_client, archive):

--- a/web/app.py
+++ b/web/app.py
@@ -1626,21 +1626,12 @@ def admin_run_now():
     if _is_running():
         flash("TubeNews is already running.", "info")
         return redirect(url_for("admin_runs"))
-    run_logs_dir = STORAGE_ROOT / "_run_logs"
-    run_logs_dir.mkdir(exist_ok=True)
-    # Open a placeholder log file; rename to run-{pid}.log once we have the PID.
-    tmp_log = run_logs_dir / ".run-starting.log"
-    with open(tmp_log, "w") as log_fh:
-        cmd = [sys.executable, str(TUBENEWS_PY)]
-        if request.form.get("debug"):
-            cmd.append("--debug")
-        proc = subprocess.Popen(
-            cmd,
-            stdout=log_fh,
-            stderr=log_fh,
-            start_new_session=True,
-        )
-    tmp_log.rename(run_logs_dir / f"run-{proc.pid}.log")
+    cmd = [sys.executable, str(TUBENEWS_PY)]
+    if request.form.get("debug"):
+        cmd.append("--debug")
+    # TubeNews.py writes its own run-<pid>.log via a FileHandler added after
+    # lock acquisition, so no stdout/stderr redirect is needed here.
+    proc = subprocess.Popen(cmd, start_new_session=True)
     _web_ntfy("TubeNews: run started", f"Manual run triggered by {current_user.email}.")
     flash("TubeNews run started.", "success")
     return redirect(url_for("admin_runs") + "?starting=1")


### PR DESCRIPTION
Previously run-<pid>.log was only created when triggered via the web UI (admin_run_now redirected stdout/stderr to the file). Cron runs wrote nothing visible in the Runs page.

Now TubeNews.py calls _add_run_log_file_handler() after acquiring the lock, adding a FileHandler that writes run-<pid>.log directly. Every run — cron, terminal, or web UI — produces an identical log file that the admin_run_log view can read and display.

admin_run_now no longer pre-creates a placeholder log file or redirects subprocess stdout/stderr; TubeNews.py owns that file. Updated the corresponding test to verify no stdout/stderr kwargs are passed to Popen.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN