### PR TITLE
Add per-story comments shared among all logged-in users

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -2861,3 +2861,122 @@ def test_mark_all_unread_with_bundle_slug(logged_in_client, archive, monkeypatch
         read = set(data.get("read_articles", []))
         assert alpha_hash not in read, "bundle mark-all-unread should have removed alpha hash"
         assert beta_hash in read, "bundle mark-all-unread must not touch other channels"
+
+# ---------------------------------------------------------------------------
+# Story comments
+# ---------------------------------------------------------------------------
+
+def test_get_comments_empty(logged_in_client, archive, monkeypatch):
+    """GET /comments/... returns [] when no comment file exists."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    r = logged_in_client.get("/comments/alpha_city/2026-01-15_VID12345678/01_Story")
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_post_comment_saves_to_file(logged_in_client, archive, monkeypatch):
+    """POST /comment must append a comment dict to the story's _comments.json."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    r = logged_in_client.post("/comment", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "body":         "Great reporting!",
+    })
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+    comment_path = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story_comments.json"
+    assert comment_path.exists()
+    comments = _json.loads(comment_path.read_text())
+    assert len(comments) == 1
+    assert comments[0]["body"] == "Great reporting!"
+
+
+def test_post_comment_requires_login(client, archive, monkeypatch):
+    """POST /comment without authentication must redirect to login."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    r = client.post("/comment", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "body":         "Hello",
+    })
+    assert r.status_code in (302, 401)
+
+
+def test_get_comments_returns_posted_comment(logged_in_client, archive, monkeypatch):
+    """GET /comments/... must return the comment that was just posted."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    logged_in_client.post("/comment", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "body":         "Test comment",
+    })
+    r = logged_in_client.get("/comments/alpha_city/2026-01-15_VID12345678/01_Story")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data) == 1
+    assert data[0]["body"] == "Test comment"
+    assert data[0]["is_mine"] is True
+
+
+def test_post_comment_empty_body_rejected(logged_in_client, archive, monkeypatch):
+    """POST /comment with an empty body must return 400."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    r = logged_in_client.post("/comment", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "body":         "   ",
+    })
+    assert r.status_code == 400
+
+
+def test_admin_comment_delete_removes_comment(admin_client, archive, monkeypatch):
+    """POST /admin/comment/delete must remove the comment at the given index."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    # Write two comments directly to the file (admin_client user has no subscriptions).
+    comment_path = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story_comments.json"
+    comment_path.write_text(_json.dumps([
+        {"user_id": "uid1", "user_name": "Alice", "posted_at": 1.0, "body": "First comment"},
+        {"user_id": "uid2", "user_name": "Bob",   "posted_at": 2.0, "body": "Second comment"},
+    ]))
+    r = admin_client.post("/admin/comment/delete", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "idx":          "0",
+    })
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+    remaining = _json.loads(comment_path.read_text())
+    assert len(remaining) == 1
+    assert remaining[0]["body"] == "Second comment"
+
+
+def test_post_comment_path_traversal_rejected(logged_in_client, archive, monkeypatch):
+    """POST /comment with path-traversal characters in channel_slug must return 400."""
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    r = logged_in_client.post("/comment", data={
+        "channel_slug": "../_users",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "body":         "Hello",
+    })
+    assert r.status_code == 400

--- a/web/app.py
+++ b/web/app.py
@@ -76,6 +76,10 @@ USERS_ROOT = STORAGE_ROOT / "_users"
 LOCK_FILE = STORAGE_ROOT / ".tubenews.lock"
 TUBENEWS_PY = BASE_DIR / "TubeNews.py"
 
+# Path-component validation for comment routes.
+_SAFE_SLUG_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_-]*$')
+_STORY_FILE_RE = re.compile(r'^\d{2}_[A-Za-z0-9_]+\.md$')
+
 # ---------------------------------------------------------------------------
 # App setup
 # ---------------------------------------------------------------------------
@@ -1346,6 +1350,89 @@ def account_mark_unstarred():
 
 
 # ---------------------------------------------------------------------------
+# Comment routes
+# ---------------------------------------------------------------------------
+
+
+@app.route("/comments/<channel_slug>/<meeting_id>/<basename>")
+@login_required
+def get_story_comments(channel_slug: str, meeting_id: str, basename: str):
+    """Return the comment list for a story as JSON.
+
+    User names are resolved lazily: if a commenter's account has been deleted,
+    their stored user_id will no longer resolve and the name shows as
+    'Deleted User' without any modification to the comment file.
+    """
+    if (not _SAFE_SLUG_RE.match(channel_slug) or
+            not _SAFE_SLUG_RE.match(meeting_id) or
+            not _SAFE_SLUG_RE.match(basename)):
+        abort(400)
+    comment_path = STORAGE_ROOT / channel_slug / meeting_id / f"{basename}_comments.json"
+    if not comment_path.exists():
+        return jsonify([])
+    try:
+        comments = json.loads(comment_path.read_text(encoding="utf-8"))
+    except Exception:
+        return jsonify([])
+    name_cache: dict[str, str] = {}
+    my_id = current_user.get_id()
+    result = []
+    for i, c in enumerate(comments):
+        uid = c.get("user_id", "")
+        if uid not in name_cache:
+            try:
+                upath = USERS_ROOT / uid / "user.json"
+                name_cache[uid] = (json.loads(upath.read_text()).get("name", "Deleted User")
+                                   if upath.exists() else "Deleted User")
+            except Exception:
+                name_cache[uid] = "Deleted User"
+        result.append({
+            "idx": i,
+            "user_name": name_cache[uid],
+            "is_mine": uid == my_id,
+            "posted_at": c.get("posted_at", 0.0),
+            "body": c.get("body", ""),
+        })
+    return jsonify(result)
+
+
+@app.route("/comment", methods=["POST"])
+@login_required
+@limiter.limit("10 per minute")
+def post_comment():
+    """Append a comment to a story's comment file. Returns JSON."""
+    channel_slug = request.form.get("channel_slug", "").strip()
+    meeting_id = request.form.get("meeting_id", "").strip()
+    filename = request.form.get("filename", "").strip()
+    body = request.form.get("body", "").strip()[:2000]
+    if (not _SAFE_SLUG_RE.match(channel_slug) or
+            not _SAFE_SLUG_RE.match(meeting_id) or
+            not _STORY_FILE_RE.match(filename)):
+        abort(400)
+    if not body:
+        return jsonify({"ok": False, "error": "Comment cannot be empty."}), 400
+    basename = filename[:-3]
+    comment_path = STORAGE_ROOT / channel_slug / meeting_id / f"{basename}_comments.json"
+    if not comment_path.parent.is_dir():
+        abort(404)
+    new_comment = {
+        "user_id": current_user.get_id(),
+        "user_name": current_user.name,
+        "posted_at": time.time(),
+        "body": body,
+    }
+    try:
+        existing = json.loads(comment_path.read_text(encoding="utf-8")) if comment_path.exists() else []
+    except Exception:
+        existing = []
+    existing.append(new_comment)
+    tmp = comment_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    tmp.rename(comment_path)
+    return jsonify({"ok": True, "count": len(existing)})
+
+
+# ---------------------------------------------------------------------------
 # Admin routes
 # ---------------------------------------------------------------------------
 
@@ -1720,6 +1807,39 @@ def admin_story_delete():
 
     flash(f'Story deleted: \u201c{story_title}\u201d', "info")
     return redirect(url_for("admin_all_stories"))
+
+
+@app.route("/admin/comment/delete", methods=["POST"])
+@login_required
+@admin_required
+def admin_comment_delete():
+    """Delete a single comment by index from a story's comment file. Returns JSON."""
+    channel_slug = request.form.get("channel_slug", "").strip()
+    meeting_id   = request.form.get("meeting_id",   "").strip()
+    filename     = request.form.get("filename",      "").strip()
+    try:
+        idx = int(request.form.get("idx", ""))
+    except (ValueError, TypeError):
+        abort(400)
+    if (not _SAFE_SLUG_RE.match(channel_slug) or
+            not _SAFE_SLUG_RE.match(meeting_id) or
+            not _STORY_FILE_RE.match(filename)):
+        abort(400)
+    basename = filename[:-3]
+    comment_path = STORAGE_ROOT / channel_slug / meeting_id / f"{basename}_comments.json"
+    if not comment_path.exists():
+        abort(404)
+    try:
+        comments = json.loads(comment_path.read_text(encoding="utf-8"))
+    except Exception:
+        abort(500)
+    if idx < 0 or idx >= len(comments):
+        abort(400)
+    del comments[idx]
+    tmp = comment_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(comments, indent=2), encoding="utf-8")
+    tmp.rename(comment_path)
+    return jsonify({"ok": True})
 
 
 @app.route("/admin/feeds")

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -908,3 +908,85 @@ main:has(.blog-layout) {
   margin-top: 2rem;
   font-size: 0.95rem;
 }
+
+/* ── Story comments ──────────────────────────────────────────── */
+
+.story-comments {
+  border-top: 1px solid var(--border);
+  padding: 0.75rem 0 0.25rem;
+  margin-top: 0.25rem;
+}
+
+.sc-comment {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.sc-comment:last-of-type { border-bottom: none; }
+
+.sc-comment-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.2rem;
+  flex-wrap: wrap;
+}
+
+.sc-author { font-weight: 600; font-size: 0.85rem; }
+.sc-time   { font-size: 0.78rem; color: var(--muted); }
+.sc-you    { font-weight: 400; color: var(--muted); }
+
+.sc-body {
+  margin: 0;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.sc-empty { color: var(--muted); font-size: 0.88rem; margin: 0.25rem 0 0.5rem; }
+
+.sc-delete {
+  margin-left: auto;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.4rem;
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+.sc-delete:hover { color: var(--bg); background: var(--danger, #c00); border-color: var(--danger, #c00); }
+
+.sc-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  margin-top: 0.75rem;
+}
+
+.sc-input {
+  flex: 1;
+  font-size: 0.88rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface, var(--bg));
+  color: var(--text);
+  resize: vertical;
+  font-family: inherit;
+  min-height: 2.5rem;
+}
+
+.sc-submit {
+  font-size: 0.82rem;
+  padding: 0.35rem 0.75rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  white-space: nowrap;
+  align-self: flex-end;
+}
+.sc-submit:hover { background: var(--accent-hover, var(--accent)); filter: brightness(1.1); }
+.sc-submit:disabled { opacity: 0.6; cursor: default; }

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -154,7 +154,22 @@
                 data-filename="{{ story.story_filename }}"
                 data-confirm="Delete &ldquo;{{ story.title | e }}&rdquo;?&#10;This cannot be undone.">&#10060; Delete</button>
         {% endif %}
+        {% if current_user.is_authenticated and story.channel_slug and story.meeting_id and story.story_filename %}
+        <button type="button" class="tb-comments"
+                data-channel-slug="{{ story.channel_slug }}"
+                data-meeting-id="{{ story.meeting_id }}"
+                data-filename="{{ story.story_filename }}">&#128172; Comments</button>
+        {% endif %}
       </div>
+      {% if current_user.is_authenticated and story.channel_slug and story.meeting_id and story.story_filename %}
+      <div class="story-comments" style="display:none">
+        <div class="sc-list"></div>
+        <form class="sc-form">
+          <textarea class="sc-input" placeholder="Add a comment&hellip;" rows="2"></textarea>
+          <button type="button" class="sc-submit">Post</button>
+        </form>
+      </div>
+      {% endif %}
     </article>
     {% endfor %}
   {% else %}
@@ -439,6 +454,127 @@
           else { alert('Delete failed (' + r.status + ').'); }
         })
         .catch(function () { alert('Delete failed. Check your connection.'); });
+    });
+  });
+})();
+{% endif %}
+
+{% if current_user.is_authenticated %}
+(function () {
+  var csrfToken    = {{ csrf_token() | tojson }};
+  var commentUrl   = {{ url_for('post_comment') | tojson }};
+  {% if current_user.is_admin %}
+  var delCommentUrl = {{ url_for('admin_comment_delete') | tojson }};
+  {% endif %}
+  var isAdmin = {{ 'true' if current_user.is_admin else 'false' }};
+
+  function escHtml(s) {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+                    .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+  }
+
+  function fmtTime(ts) {
+    if (!ts) return '';
+    var d = new Date(ts * 1000);
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+  }
+
+  function renderComments(section, comments) {
+    var list = section.querySelector('.sc-list');
+    if (!comments.length) {
+      list.innerHTML = '<p class="sc-empty">No comments yet. Be the first!</p>';
+      return;
+    }
+    list.innerHTML = comments.map(function (c) {
+      return '<div class="sc-comment" data-idx="' + c.idx + '">' +
+        '<div class="sc-comment-meta">' +
+        '<span class="sc-author">' + escHtml(c.user_name) +
+        (c.is_mine ? ' <span class="sc-you">(you)</span>' : '') + '</span>' +
+        '<span class="sc-time">' + fmtTime(c.posted_at) + '</span>' +
+        (isAdmin ? '<button class="sc-delete" data-idx="' + c.idx + '">&#10060;</button>' : '') +
+        '</div>' +
+        '<p class="sc-body">' + escHtml(c.body).replace(/\n/g, '<br>') + '</p>' +
+        '</div>';
+    }).join('');
+    if (isAdmin) {
+      list.querySelectorAll('.sc-delete').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          if (!confirm('Delete this comment?')) return;
+          var fd = new FormData();
+          fd.append('csrf_token', csrfToken);
+          fd.append('channel_slug', section.dataset.channelSlug);
+          fd.append('meeting_id',   section.dataset.meetingId);
+          fd.append('filename',     section.dataset.filename);
+          fd.append('idx',          btn.dataset.idx);
+          fetch(delCommentUrl, { method: 'POST', body: fd })
+            .then(function (r) { return r.json(); })
+            .then(function (res) {
+              if (res.ok) { loadComments(section); }
+              else { alert('Delete failed.'); }
+            })
+            .catch(function () { alert('Delete failed.'); });
+        });
+      });
+    }
+  }
+
+  function updateToggle(section, count) {
+    var btn = section.closest('article').querySelector('.tb-comments');
+    if (btn) btn.textContent = '&#128172; Comments' + (count ? ' (' + count + ')' : '');
+  }
+
+  function loadComments(section) {
+    var slug = section.dataset.channelSlug;
+    var mid  = section.dataset.meetingId;
+    var base = section.dataset.filename.replace(/\.md$/, '');
+    section.querySelector('.sc-list').innerHTML = '<p class="sc-empty">Loading\u2026</p>';
+    fetch('/comments/' + slug + '/' + mid + '/' + base)
+      .then(function (r) { return r.json(); })
+      .then(function (comments) {
+        renderComments(section, comments);
+        updateToggle(section, comments.length);
+      })
+      .catch(function () {
+        section.querySelector('.sc-list').innerHTML = '<p class="sc-empty">Could not load comments.</p>';
+      });
+  }
+
+  document.querySelectorAll('.tb-comments').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var section = btn.closest('article').querySelector('.story-comments');
+      if (section.style.display !== 'none') {
+        section.style.display = 'none';
+        return;
+      }
+      section.dataset.channelSlug = btn.dataset.channelSlug;
+      section.dataset.meetingId   = btn.dataset.meetingId;
+      section.dataset.filename    = btn.dataset.filename;
+      section.style.display = '';
+      loadComments(section);
+    });
+  });
+
+  document.querySelectorAll('.sc-submit').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var section  = btn.closest('.story-comments');
+      var textarea = section.querySelector('.sc-input');
+      var body = textarea.value.trim();
+      if (!body) { textarea.focus(); return; }
+      var fd = new FormData();
+      fd.append('csrf_token',   csrfToken);
+      fd.append('channel_slug', section.dataset.channelSlug);
+      fd.append('meeting_id',   section.dataset.meetingId);
+      fd.append('filename',     section.dataset.filename);
+      fd.append('body',         body);
+      btn.disabled = true;
+      fetch(commentUrl, { method: 'POST', body: fd })
+        .then(function (r) { return r.json(); })
+        .then(function (res) {
+          if (res.ok) { textarea.value = ''; loadComments(section); }
+          else { alert(res.error || 'Failed to post comment.'); }
+        })
+        .catch(function () { alert('Failed to post comment.'); })
+        .finally(function () { btn.disabled = false; });
     });
   });
 })();


### PR DESCRIPTION
Storage: <story_basename>_comments.json alongside the .md file. User names are resolved lazily at serve time; deleted accounts automatically show as 'Deleted User' without any migration.

Routes:
  GET  /comments/<channel_slug>/<meeting_id>/<basename>  – JSON list
  POST /comment                                          – append (10/min)
  POST /admin/comment/delete                             – admin delete by idx

UI: 'Comments' button in the story toolbar expands a collapsible section below each story. Comments load via fetch() on expand; new comments post via fetch() without a page reload. Admins see a per-comment delete button.

Path traversal guarded by _SAFE_SLUG_RE and _STORY_FILE_RE regexes. 7 new tests covering empty list, post, login guard, empty body rejection, admin delete, and path traversal rejection.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN