### PR TITLE
Add comment counts, owner edit/delete, and fix HTML entity rendering

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -2968,6 +2968,140 @@ def test_admin_comment_delete_removes_comment(admin_client, archive, monkeypatch
     assert remaining[0]["body"] == "Second comment"
 
 
+def test_comment_delete_owner_can_delete_own_comment(logged_in_client, archive, monkeypatch):
+    """POST /comment/delete allows the comment owner to delete their own comment."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    # Post a comment as the logged-in user, then delete it.
+    logged_in_client.post("/comment", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "body":         "My own comment",
+    })
+    r = logged_in_client.post("/comment/delete", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "idx":          "0",
+    })
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+    comment_path = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story_comments.json"
+    assert _json.loads(comment_path.read_text()) == []
+
+
+def test_comment_delete_non_owner_rejected(logged_in_client, archive, monkeypatch):
+    """POST /comment/delete returns 403 when the requester does not own the comment."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    comment_path = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story_comments.json"
+    comment_path.write_text(_json.dumps([
+        {"user_id": "someone-elses-uuid", "user_name": "Other", "posted_at": 1.0, "body": "Not mine"},
+    ]))
+    r = logged_in_client.post("/comment/delete", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "idx":          "0",
+    })
+    assert r.status_code == 403
+
+
+def test_comment_delete_admin_can_delete_any_comment(admin_client, archive, monkeypatch):
+    """POST /comment/delete allows an admin to delete any comment."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    comment_path = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story_comments.json"
+    comment_path.write_text(_json.dumps([
+        {"user_id": "someone-elses-uuid", "user_name": "Other", "posted_at": 1.0, "body": "Other comment"},
+    ]))
+    r = admin_client.post("/comment/delete", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "idx":          "0",
+    })
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+
+
+def test_comment_edit_owner_can_edit_own_comment(logged_in_client, archive, monkeypatch):
+    """POST /comment/edit allows the owner to update their comment body."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    # Post a comment, then edit it.
+    logged_in_client.post("/comment", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "body":         "Original body",
+    })
+    r = logged_in_client.post("/comment/edit", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "idx":          "0",
+        "body":         "Edited body",
+    })
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+    comment_path = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story_comments.json"
+    comments = _json.loads(comment_path.read_text())
+    assert comments[0]["body"] == "Edited body"
+    assert "edited_at" in comments[0]
+
+
+def test_comment_edit_non_owner_rejected(logged_in_client, archive, monkeypatch):
+    """POST /comment/edit returns 403 when the requester does not own the comment."""
+    import json as _json
+    import web.app as _wa
+    monkeypatch.setattr(_wa, "STORAGE_ROOT", archive)
+    monkeypatch.setattr(_wa, "USERS_ROOT", archive / "_users")
+    comment_path = archive / "alpha_city" / "2026-01-15_VID12345678" / "01_Story_comments.json"
+    comment_path.write_text(_json.dumps([
+        {"user_id": "someone-elses-uuid", "user_name": "Other", "posted_at": 1.0, "body": "Not mine"},
+    ]))
+    r = logged_in_client.post("/comment/edit", data={
+        "channel_slug": "alpha_city",
+        "meeting_id":   "2026-01-15_VID12345678",
+        "filename":     "01_Story.md",
+        "idx":          "0",
+        "body":         "Attempted edit",
+    })
+    assert r.status_code == 403
+
+
+def test_story_comment_count_returns_zero_when_no_file(tmp_path):
+    """_story_comment_count returns 0 when no comment file exists."""
+    import web.app as _wa
+    story_file = tmp_path / "01_Story.md"
+    story_file.write_text("# Title\n*Dateline*\n\nBody.\n")
+    assert _wa._story_comment_count(story_file) == 0
+
+
+def test_story_comment_count_returns_correct_count(tmp_path):
+    """_story_comment_count returns the number of comments in the file."""
+    import json as _json
+    import web.app as _wa
+    story_file = tmp_path / "01_Story.md"
+    story_file.write_text("# Title\n*Dateline*\n\nBody.\n")
+    comment_file = tmp_path / "01_Story_comments.json"
+    comment_file.write_text(_json.dumps([
+        {"user_id": "u1", "body": "A", "posted_at": 1.0},
+        {"user_id": "u2", "body": "B", "posted_at": 2.0},
+    ]))
+    assert _wa._story_comment_count(story_file) == 2
+
+
 def test_post_comment_path_traversal_rejected(logged_in_client, archive, monkeypatch):
     """POST /comment with path-traversal characters in channel_slug must return 400."""
     import web.app as _wa

--- a/web/app.py
+++ b/web/app.py
@@ -578,6 +578,17 @@ def _bundle_counts(stories: list[StoryDict], bundles: list[dict]) -> list[dict]:
     return result
 
 
+def _story_comment_count(story_file: Path) -> int:
+    """Return the number of comments for a story file, or 0 if none."""
+    comment_file = story_file.with_name(story_file.stem + "_comments.json")
+    if not comment_file.exists():
+        return 0
+    try:
+        return len(json.loads(comment_file.read_text(encoding="utf-8")))
+    except Exception:
+        return 0
+
+
 def _get_channel_stories(channel_id: str) -> tuple[str | None, list[StoryDict]]:
     """Return (channel_name, stories) for a single channel, newest-first.
 
@@ -630,6 +641,7 @@ def _get_channel_stories(channel_id: str) -> tuple[str | None, list[StoryDict]]:
                     "story_filename": entry["file"].name,
                     "processed_at": entry["meta"].get("processed_at", 0),
                     "channel_id": channel_id,
+                    "comment_count": _story_comment_count(entry["file"]),
                 })
             except Exception as exc:
                 logger.debug(f"Skipping {entry['file']}: {exc}")
@@ -692,6 +704,7 @@ def _get_user_stories(user_data: dict, user_id: str = "") -> list[StoryDict]:
                 "processed_at": entry["meta"].get("processed_at", 0),
                 "content_hash": s.get("content_hash", ""),
                 "channel_id": entry["channel_id"],
+                "comment_count": _story_comment_count(entry["file"]),
             })
         except Exception as exc:
             logger.debug(f"Skipping {entry['file']}: {exc}")
@@ -1386,13 +1399,16 @@ def get_story_comments(channel_slug: str, meeting_id: str, basename: str):
                                    if upath.exists() else "Deleted User")
             except Exception:
                 name_cache[uid] = "Deleted User"
-        result.append({
+        entry: dict = {
             "idx": i,
             "user_name": name_cache[uid],
             "is_mine": uid == my_id,
             "posted_at": c.get("posted_at", 0.0),
             "body": c.get("body", ""),
-        })
+        }
+        if "edited_at" in c:
+            entry["edited_at"] = c["edited_at"]
+        result.append(entry)
     return jsonify(result)
 
 
@@ -1430,6 +1446,79 @@ def post_comment():
     tmp.write_text(json.dumps(existing, indent=2), encoding="utf-8")
     tmp.rename(comment_path)
     return jsonify({"ok": True, "count": len(existing)})
+
+
+@app.route("/comment/delete", methods=["POST"])
+@login_required
+def comment_delete():
+    """Delete a comment. Allowed for the comment owner or any admin."""
+    channel_slug = request.form.get("channel_slug", "").strip()
+    meeting_id   = request.form.get("meeting_id",   "").strip()
+    filename     = request.form.get("filename",      "").strip()
+    try:
+        idx = int(request.form.get("idx", ""))
+    except (ValueError, TypeError):
+        abort(400)
+    if (not _SAFE_SLUG_RE.match(channel_slug) or
+            not _SAFE_SLUG_RE.match(meeting_id) or
+            not _STORY_FILE_RE.match(filename)):
+        abort(400)
+    basename = filename[:-3]
+    comment_path = STORAGE_ROOT / channel_slug / meeting_id / f"{basename}_comments.json"
+    if not comment_path.exists():
+        abort(404)
+    try:
+        comments = json.loads(comment_path.read_text(encoding="utf-8"))
+    except Exception:
+        abort(500)
+    if idx < 0 or idx >= len(comments):
+        abort(400)
+    my_id = current_user.get_id()
+    if comments[idx].get("user_id") != my_id and not current_user.is_admin:
+        abort(403)
+    del comments[idx]
+    tmp = comment_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(comments, indent=2), encoding="utf-8")
+    tmp.rename(comment_path)
+    return jsonify({"ok": True})
+
+
+@app.route("/comment/edit", methods=["POST"])
+@login_required
+def comment_edit():
+    """Edit a comment body. Allowed only for the comment owner."""
+    channel_slug = request.form.get("channel_slug", "").strip()
+    meeting_id   = request.form.get("meeting_id",   "").strip()
+    filename     = request.form.get("filename",      "").strip()
+    body         = request.form.get("body",          "").strip()[:2000]
+    try:
+        idx = int(request.form.get("idx", ""))
+    except (ValueError, TypeError):
+        abort(400)
+    if (not _SAFE_SLUG_RE.match(channel_slug) or
+            not _SAFE_SLUG_RE.match(meeting_id) or
+            not _STORY_FILE_RE.match(filename)):
+        abort(400)
+    if not body:
+        return jsonify({"ok": False, "error": "Comment cannot be empty."}), 400
+    basename = filename[:-3]
+    comment_path = STORAGE_ROOT / channel_slug / meeting_id / f"{basename}_comments.json"
+    if not comment_path.exists():
+        abort(404)
+    try:
+        comments = json.loads(comment_path.read_text(encoding="utf-8"))
+    except Exception:
+        abort(500)
+    if idx < 0 or idx >= len(comments):
+        abort(400)
+    if comments[idx].get("user_id") != current_user.get_id():
+        abort(403)
+    comments[idx]["body"] = body
+    comments[idx]["edited_at"] = time.time()
+    tmp = comment_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(comments, indent=2), encoding="utf-8")
+    tmp.rename(comment_path)
+    return jsonify({"ok": True})
 
 
 # ---------------------------------------------------------------------------

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -945,8 +945,7 @@ main:has(.blog-layout) {
 
 .sc-empty { color: var(--muted); font-size: 0.88rem; margin: 0.25rem 0 0.5rem; }
 
-.sc-delete {
-  margin-left: auto;
+.sc-delete, .sc-edit {
   font-size: 0.75rem;
   padding: 0.1rem 0.4rem;
   background: transparent;
@@ -955,7 +954,14 @@ main:has(.blog-layout) {
   border-radius: var(--radius);
   cursor: pointer;
 }
+.sc-delete { margin-left: auto; }
+.sc-edit   { margin-left: auto; margin-right: 0.25rem; }
 .sc-delete:hover { color: var(--bg); background: var(--danger, #c00); border-color: var(--danger, #c00); }
+.sc-edit:hover   { color: var(--bg); background: var(--accent);       border-color: var(--accent); }
+
+.sc-edit-input { display: block; width: 100%; margin-top: 0.25rem; }
+.sc-save   { margin-top: 0.4rem; margin-right: 0.4rem; }
+.sc-cancel { margin-top: 0.4rem; }
 
 .sc-form {
   display: flex;

--- a/web/templates/blog.html
+++ b/web/templates/blog.html
@@ -158,7 +158,7 @@
         <button type="button" class="tb-comments"
                 data-channel-slug="{{ story.channel_slug }}"
                 data-meeting-id="{{ story.meeting_id }}"
-                data-filename="{{ story.story_filename }}">&#128172; Comments</button>
+                data-filename="{{ story.story_filename }}">&#128172; Comments{% if story.comment_count %} ({{ story.comment_count }}){% endif %}</button>
         {% endif %}
       </div>
       {% if current_user.is_authenticated and story.channel_slug and story.meeting_id and story.story_filename %}
@@ -461,11 +461,10 @@
 
 {% if current_user.is_authenticated %}
 (function () {
-  var csrfToken    = {{ csrf_token() | tojson }};
-  var commentUrl   = {{ url_for('post_comment') | tojson }};
-  {% if current_user.is_admin %}
-  var delCommentUrl = {{ url_for('admin_comment_delete') | tojson }};
-  {% endif %}
+  var csrfToken     = {{ csrf_token() | tojson }};
+  var commentUrl    = {{ url_for('post_comment') | tojson }};
+  var delCommentUrl = {{ url_for('comment_delete') | tojson }};
+  var editCommentUrl = {{ url_for('comment_edit') | tojson }};
   var isAdmin = {{ 'true' if current_user.is_admin else 'false' }};
 
   function escHtml(s) {
@@ -486,41 +485,87 @@
       return;
     }
     list.innerHTML = comments.map(function (c) {
+      var canDelete = c.is_mine || isAdmin;
+      var canEdit   = c.is_mine;
       return '<div class="sc-comment" data-idx="' + c.idx + '">' +
         '<div class="sc-comment-meta">' +
         '<span class="sc-author">' + escHtml(c.user_name) +
         (c.is_mine ? ' <span class="sc-you">(you)</span>' : '') + '</span>' +
-        '<span class="sc-time">' + fmtTime(c.posted_at) + '</span>' +
-        (isAdmin ? '<button class="sc-delete" data-idx="' + c.idx + '">&#10060;</button>' : '') +
+        '<span class="sc-time">' + fmtTime(c.posted_at) + (c.edited_at ? ' (edited)' : '') + '</span>' +
+        (canEdit   ? '<button class="sc-edit"   data-idx="' + c.idx + '">Edit</button>'  : '') +
+        (canDelete ? '<button class="sc-delete" data-idx="' + c.idx + '">&#10060;</button>' : '') +
         '</div>' +
         '<p class="sc-body">' + escHtml(c.body).replace(/\n/g, '<br>') + '</p>' +
         '</div>';
     }).join('');
-    if (isAdmin) {
-      list.querySelectorAll('.sc-delete').forEach(function (btn) {
-        btn.addEventListener('click', function () {
-          if (!confirm('Delete this comment?')) return;
+    list.querySelectorAll('.sc-delete').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        if (!confirm('Delete this comment?')) return;
+        var fd = new FormData();
+        fd.append('csrf_token', csrfToken);
+        fd.append('channel_slug', section.dataset.channelSlug);
+        fd.append('meeting_id',   section.dataset.meetingId);
+        fd.append('filename',     section.dataset.filename);
+        fd.append('idx',          btn.dataset.idx);
+        fetch(delCommentUrl, { method: 'POST', body: fd })
+          .then(function (r) { return r.json(); })
+          .then(function (res) {
+            if (res.ok) { loadComments(section); }
+            else { alert('Delete failed.'); }
+          })
+          .catch(function () { alert('Delete failed.'); });
+      });
+    });
+    list.querySelectorAll('.sc-edit').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var commentEl = btn.closest('.sc-comment');
+        var bodyEl    = commentEl.querySelector('.sc-body');
+        var existing  = bodyEl.innerText || bodyEl.textContent;
+        // Replace body with inline textarea + save/cancel
+        commentEl.querySelector('.sc-comment-meta').querySelectorAll('.sc-edit').forEach(function (b) { b.disabled = true; });
+        var ta = document.createElement('textarea');
+        ta.className = 'sc-input sc-edit-input';
+        ta.rows = 3;
+        ta.value = existing;
+        var saveBtn   = document.createElement('button');
+        saveBtn.type  = 'button';
+        saveBtn.className = 'sc-submit sc-save';
+        saveBtn.textContent = 'Save';
+        var cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'btn-sm sc-cancel';
+        cancelBtn.textContent = 'Cancel';
+        bodyEl.replaceWith(ta);
+        commentEl.appendChild(saveBtn);
+        commentEl.appendChild(cancelBtn);
+        btn.disabled = true;
+        cancelBtn.addEventListener('click', function () { loadComments(section); });
+        saveBtn.addEventListener('click', function () {
+          var newBody = ta.value.trim();
+          if (!newBody) { ta.focus(); return; }
           var fd = new FormData();
           fd.append('csrf_token', csrfToken);
           fd.append('channel_slug', section.dataset.channelSlug);
           fd.append('meeting_id',   section.dataset.meetingId);
           fd.append('filename',     section.dataset.filename);
           fd.append('idx',          btn.dataset.idx);
-          fetch(delCommentUrl, { method: 'POST', body: fd })
+          fd.append('body',         newBody);
+          saveBtn.disabled = true;
+          fetch(editCommentUrl, { method: 'POST', body: fd })
             .then(function (r) { return r.json(); })
             .then(function (res) {
               if (res.ok) { loadComments(section); }
-              else { alert('Delete failed.'); }
+              else { alert(res.error || 'Edit failed.'); saveBtn.disabled = false; }
             })
-            .catch(function () { alert('Delete failed.'); });
+            .catch(function () { alert('Edit failed.'); saveBtn.disabled = false; });
         });
       });
-    }
+    });
   }
 
   function updateToggle(section, count) {
     var btn = section.closest('article').querySelector('.tb-comments');
-    if (btn) btn.textContent = '&#128172; Comments' + (count ? ' (' + count + ')' : '');
+    if (btn) btn.innerHTML = '&#128172; Comments' + (count ? ' (' + count + ')' : '');
   }
 
   function loadComments(section) {


### PR DESCRIPTION
- Add _story_comment_count() helper; pre-render count on Comments button so non-zero counts are visible without clicking
- Fix updateToggle() using innerHTML instead of textContent so the speech-bubble emoji renders correctly (was showing literal &#128172;)
- Add POST /comment/delete (owner or admin) and POST /comment/edit (owner only) routes; /admin/comment/delete remains for backward compat
- Return edited_at in GET /comments response; show "(edited)" label
- Show Edit and Delete buttons in comment list for owners (admin still sees Delete on any comment); inline textarea edit UI with Save/Cancel
- Add CSS for .sc-edit, .sc-edit-input, .sc-save, .sc-cancel
- Add _story_comment_count to _get_channel_stories story dicts
- 7 new tests covering owner delete, non-owner rejection, admin delete on any comment, owner edit, non-owner edit rejection, and count helper

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN