### PR TITLE
Replace YouTube HTML scraping with official RSS feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ TubeNews/
 ├── helpers/
 │   ├── catchup.py           # Mark all existing videos as "too old" (first-run util)
 │   ├── check_quota.py       # Test Gemini API key quota across models
-│   ├── dump_channel_html.py # Dump raw ytInitialData JSON for debugging YouTube scraper changes
+│   ├── dump_channel_html.py # Dump raw ytInitialData JSON (legacy debug tool — no longer used by main scraper)
 │   └── reset_password.py    # Emergency CLI password reset (for locked-out admins)
 └── web/
     ├── app.py               # Flask web UI (user accounts, subscriptions, admin)
@@ -46,12 +46,12 @@ TubeNews/
 ## Architecture & Data Flow
 
 ```
-YouTube Channel Pages (HTML scrape)
+YouTube channel Atom RSS feed
          │
-         ▼  list of {id, title, date, is_live}
+         ▼  list of {id, title, date}
   discover_videos()
-         │  (parses ytInitialData JSON embedded in channel page;
-         │   title and approximate date extracted here — no per-video watch-page request)
+         │  (fetches https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID;
+         │   returns up to 15 most-recent entries with exact ISO dates)
          │
          ▼  IDs not yet in content store
   process_feed() ──► process_video() (one per new video)
@@ -93,7 +93,7 @@ Defined at the top of `TubeNews.py` (and importable into `web/app.py`):
 
 | TypedDict | Fields | Used by |
 |---|---|---|
-| `VideoInfo` | `id`, `title`, `date`, `is_live` (all `str`/`bool`) | `discover_videos()` return type |
+| `VideoInfo` | `id`, `title`, `date` (all `str`) | `discover_videos()` return type |
 | `FeedConfig` | `channel_id`, `channel_name`, `focus` (all `str`) | Config array entries; `rebuild_feed`, `process_feed`, `process_video` parameters |
 | `GeminiStory` | `title`, `dateline`, `content` (`str`), `start_time_seconds` (`int`), `topics` (`list[str]`) | `call_gemini_api()` return type; `write_story_files()` input |
 | `ParsedStory` | `title`, `dateline`, `body_html` (`str`), `start_seconds` (`int`), `topics` (`list[str]`), `content_hash` (`str`), `user_ids` (`list[str]`) | `parse_story_file()` return type; imported by `web/app.py` |
@@ -127,10 +127,8 @@ Defined in `web/app.py`:
 
 | Function | Description |
 |---|---|
-| `_relative_date_to_iso(text)` | Converts a YouTube relative-date string (e.g. `"11 days ago"`) to `YYYY-MM-DD`; parses exact dates from completed-stream text |
-| `_parse_channel_page_metadata(html)` | Extracts `{videoId → {title, date, is_live}}` from the `ytInitialData` JSON blob embedded in a channel listing page |
-| `discover_videos(channel_id)` | Scrapes the channel's `videos` and `streams` tabs; returns `list[VideoInfo]` |
-| `fetch_transcript(video_id, supadata_client, ..., transcript_rate_limit_event=None)` | Fetches timed transcript segments from Supadata; returns formatted string or None. When a quota-exhausted error is detected (HTTP 402 or `SupadataError` with a credit-related `error` code), sets `transcript_rate_limit_event` before returning None so callers can stop immediately. |
+| `discover_videos(channel_id)` | Fetches YouTube's official Atom RSS feed (`feeds/videos.xml?channel_id=…`); returns `list[VideoInfo]` (up to 15 most-recent, exact ISO dates). Retries up to 3 times on network errors. |
+| `fetch_transcript(video_id, supadata_client, ..., transcript_rate_limit_event=None)` | Fetches timed transcript segments from Supadata; returns formatted string or None. When a quota-exhausted error is detected (HTTP 402 or `SupadataError` with a credit-related `error` code), sets `transcript_rate_limit_event` before returning None so callers can stop immediately. When Supadata raises an exception whose message contains `"live streaming"`, returns `None` (transient) so the video is retried next run without being permanently marked. |
 
 ### AI story generation
 
@@ -307,7 +305,7 @@ Story body text in AP inverted pyramid style...
 | `feeds[].channel_name` | Yes | Human-readable name; used to create `content/` subfolder |
 | `feeds[].focus` | Yes | Topic guidance for the AI (e.g. "housing, zoning, permits") |
 | `content_dir` | No | Path to the content directory (default: `content/` next to `TubeNews.py`). Use an absolute path (e.g. `/var/www/html/tubenews`) or a path relative to `TubeNews.py` to point it at your web server's document root. |
-| `request_timeout` | No | Seconds before giving up on YouTube scrape and Supadata API calls (default: `15`). Increase on slow or high-latency connections |
+| `request_timeout` | No | Seconds before giving up on YouTube RSS and Supadata API calls (default: `15`). Increase on slow or high-latency connections |
 | `gemini_call_delay` | No | Seconds to sleep between consecutive Gemini API calls within a single video's focus passes (default: `5`). Keeps call rate well under the 15 RPM free-tier limit. Set to `0` to disable. |
 | `base_url` | No | Public URL of `content/rss.xml`, used as the aggregate feed self-link |
 | `ntfy_topic` | No | ntfy.sh topic for run-summary push notifications (e.g. `"TubeNewsAdmin"`); omit to disable |
@@ -324,7 +322,7 @@ Story body text in AP inverted pyramid style...
 |---|---|---|
 | `helpers/catchup.py` | Marks all visible videos as ignored | Before first run on a channel with existing videos |
 | `helpers/check_quota.py` | Tests Gemini API key quota across models | When AI calls fail with 429 errors |
-| `helpers/dump_channel_html.py` | Dumps raw `ytInitialData` JSON for a channel tab; accepts optional `channel_id` and `tab` (`videos`\|`streams`) positional args, falls back to first configured channel / videos tab | When YouTube scraper stops finding videos/titles — inspect structure changes |
+| `helpers/dump_channel_html.py` | Dumps raw `ytInitialData` JSON for a channel tab (legacy diagnostic tool — no longer used by the main pipeline, which now uses the RSS feed) | Kept for historical reference; not needed for normal operation |
 | `helpers/reset_password.py` | Resets a user's password from the CLI | When the admin is locked out and can't log in to use the admin panel |
 
 ---
@@ -337,7 +335,7 @@ pytest tests/ -v
 
 | File | Covers |
 |---|---|
-| `tests/test_tubenews.py` | `slugify`, `parse_story_file` (including `topics`, `user_ids`, and HTML escaping in `body_html`), `_story_matches_focus`, `write_story_files` (including `**Users:**` output), `_collect_channel_focuses` (tuple return type, user-id merging), `fetch_transcript` (success path, language mismatch, live-stream skip, quota exhaustion + event flag), the JSON extraction regex in `call_gemini_api`, `rebuild_feed`, `rebuild_aggregate_feed`, `build_user_feed_xml`, lock/unlock helpers, config resolution |
+| `tests/test_tubenews.py` | `slugify`, `parse_story_file` (including `topics`, `user_ids`, and HTML escaping in `body_html`), `_story_matches_focus`, `write_story_files` (including `**Users:**` output), `_collect_channel_focuses` (tuple return type, user-id merging), `discover_videos` (RSS parse, HTTP error, malformed XML, network retry, empty feed warning, no `is_live` field), `fetch_transcript` (success path, language mismatch, live-stream skip, quota exhaustion + event flag), the JSON extraction regex in `call_gemini_api`, `rebuild_feed`, `rebuild_aggregate_feed`, `build_user_feed_xml`, lock/unlock helpers, config resolution |
 | `tests/test_web.py` | `web/app.py` URL helpers (`_feed_url`, `_blog_url`), user preferences |
 | `tests/test_webapp.py` | Flask routes: login guards, rate-limit (429 after 10 attempts), locked-account rejection, dashboard subscription save, admin guards, public token routes, lock-file detection, run-now trigger, channel browse YouTube link, admin runs channel links |
 
@@ -349,8 +347,9 @@ All tests use `tmp_path` fixtures — no network calls and no real archive neede
 
 ### External Dependencies and Fragility
 
-- **YouTube HTML scraping** (`discover_videos`, `_parse_channel_page_metadata`) parses the `ytInitialData` JSON blob embedded in channel listing pages. YouTube can change this structure at any time. If videos stop being discovered or titles/dates stop appearing, check whether the `videoId`, `title.runs`, or `publishedTimeText` JSON paths have changed. The simple `videoId` regex fallback ensures IDs are still found even if the richer metadata parse fails.
-- **Approximate dates:** The channel listing page only provides relative dates ("11 days ago"). `_relative_date_to_iso` converts these to approximate calendar dates by subtracting from today. Completed livestreams often include the exact date in the text ("Streamed live on Mar 14, 2026") and are parsed precisely.
+- **YouTube RSS feed** (`discover_videos`) fetches `https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID` — YouTube's official, stable Atom feed. It returns up to 15 most-recent videos with exact ISO 8601 publication dates. No API key, no HTML parsing, no bot-detection concerns. If video discovery stops working entirely, verify the channel ID is correct and the feed URL returns valid XML. The `helpers/dump_channel_html.py` script is kept as a legacy diagnostic tool but is no longer part of the normal workflow.
+- **Live stream handling:** The RSS feed includes in-progress livestreams with no indication they are live. When `fetch_transcript` is called for such a video, Supadata raises an exception whose message contains `"live streaming"`; `fetch_transcript` catches this and returns `None` (transient failure), so `process_video` skips the video without writing `metadata.json` and it is retried on the next run. The cost is one extra Supadata API call per live video per run until the stream ends.
+- **RSS video limit:** The YouTube Atom feed returns at most 15 entries. This is sufficient for incremental processing (new videos since the last run). `helpers/catchup.py` uses the same RSS feed, so on a first-time setup it marks the 15 most-recent videos as already processed; for channels with a deeper backlog, older stubs must be created manually or the operator must run `catchup.py` before the 16th new video is posted.
 - **Supadata API** is a paid proxy service. Check account quota if transcripts stop working. The `Transcript` object returned by `supadata_client.transcript()` exposes only `content`, `lang`, and `available_langs`.
 - **Gemini API** has rate limits per project. Use `helpers/check_quota.py` to test. If one project is exhausted, create a new Google Cloud project and generate a fresh key.
 

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -2,10 +2,9 @@
 """TubeNews — monitor YouTube channels for new videos and generate news feeds.
 
 Workflow for each configured channel (feed):
-  1. Discover recent video IDs by scraping YouTube channel pages.
+  1. Discover recent video IDs via YouTube's official Atom RSS feed.
   2. Skip videos already in the local archive.
-  3. For genuinely new videos: fetch a transcript via the Supadata API and
-     scrape basic metadata (title, upload date) from the YouTube watch page.
+  3. For genuinely new videos: fetch a transcript via the Supadata API.
   4. Send the transcript to Google Gemini so it can extract focused news
      stories and write each story as a Markdown file.
   5. Rebuild the per-channel RSS feed and the site-wide aggregate feed.
@@ -30,7 +29,8 @@ import re
 import socket
 import threading
 import time
-from datetime import date, datetime, timedelta
+import xml.etree.ElementTree as ET
+from datetime import date, datetime
 from pathlib import Path
 from typing import TypedDict
 
@@ -94,15 +94,6 @@ if os.path.exists(_FREEBSD_CERT):
 # (including Supadata's underlying HTTP) respects it automatically.
 socket.setdefaulttimeout(REQUEST_TIMEOUT)
 
-# Mimic a real browser so YouTube doesn't serve a bot-detection page instead
-# of the normal HTML (which contains the metadata we need to scrape).
-YOUTUBE_HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "Chrome/122.0.0.0 Safari/537.36"
-    )
-}
-
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -155,7 +146,6 @@ class VideoInfo(TypedDict):
     id: str
     title: str
     date: str
-    is_live: bool
 
 
 class FeedConfig(TypedDict):
@@ -331,178 +321,68 @@ def _story_matches_focus(story_topics: list[str], focuses: list[str]) -> bool:
 # YouTube data-gathering
 # ---------------------------------------------------------------------------
 
-
-def _relative_date_to_iso(text: str) -> str:
-    """Convert a YouTube relative-date string to ``YYYY-MM-DD``.
-
-    YouTube's channel listing page provides publication dates as relative
-    strings (e.g. ``"11 days ago"``, ``"2 weeks ago"``).  We subtract the
-    implied offset from today to get an approximate calendar date.
-
-    For completed live-streams YouTube sometimes provides an exact date
-    (e.g. ``"Streamed live on Feb 24, 2026"``); we parse that precisely.
-
-    Falls back to today's date for any unrecognised format.
-    """
-    today = datetime.now()
-    lower = text.lower().strip()
-
-    # "Streamed live on Month DD, YYYY" or just "Month DD, YYYY"
-    exact = re.search(r"([a-z]+ \d{1,2},\s*\d{4})", lower)
-    if exact:
-        for fmt in ("%b %d, %Y", "%B %d, %Y"):
-            try:
-                return datetime.strptime(exact.group(1), fmt).strftime("%Y-%m-%d")
-            except ValueError:
-                continue
-
-    # "N seconds/minutes/hours/days/weeks/months/years ago"
-    m = re.search(r"(\d+)\s+(second|minute|hour|day|week|month|year)s?\s+ago", lower)
-    if m:
-        n, unit = int(m.group(1)), m.group(2)
-        days = {"second": 0, "minute": 0, "hour": 0, "day": n,
-                "week": n * 7, "month": n * 30, "year": n * 365}[unit]
-        return (today - timedelta(days=days)).strftime("%Y-%m-%d")
-
-    return today.strftime("%Y-%m-%d")
-
-
-def _parse_channel_page_metadata(html: str) -> dict[str, dict]:
-    """Extract per-video metadata from the ``ytInitialData`` JSON in a channel page.
-
-    YouTube embeds a large JSON blob (``var ytInitialData = {...};``) that
-    powers the video-card grid.  Each card's ``videoRenderer`` object contains
-    the video ID, title, relative publish date, and live-stream status.
-
-    Returns a ``{videoId: {title, date, is_live}}`` mapping.
-    Falls back to an empty dict if the JSON blob is absent or unparseable.
-    """
-    result: dict[str, dict] = {}
-
-    m = re.search(
-        r"var ytInitialData\s*=\s*(\{.*?\});\s*(?:var |</script>)",
-        html,
-        re.DOTALL,
-    )
-    if not m:
-        return result
-
-    try:
-        data = json.loads(m.group(1))
-    except json.JSONDecodeError:
-        return result
-
-    def walk(obj: object) -> None:
-        if isinstance(obj, dict):
-            if "videoId" in obj and "title" in obj:
-                vid = obj["videoId"]
-                runs = obj["title"].get("runs", [])
-                title = runs[0].get("text", "") if runs else obj["title"].get("simpleText", "")
-
-                relative = obj.get("publishedTimeText", {}).get("simpleText", "")
-                date = _relative_date_to_iso(relative) if relative else datetime.now().strftime("%Y-%m-%d")
-                logger.debug(f"  video {vid}: publishedTimeText={relative!r} → date={date}")
-
-                is_live = any(
-                    ov.get("thumbnailOverlayTimeStatusRenderer", {}).get("style")
-                    in ("LIVE", "UPCOMING")
-                    for ov in obj.get("thumbnailOverlays", [])
-                )
-
-                if vid not in result:
-                    result[vid] = {"title": title, "date": date, "is_live": is_live}
-
-            for v in obj.values():
-                walk(v)
-        elif isinstance(obj, list):
-            for item in obj:
-                walk(item)
-
-    walk(data)
-    return result
+_YT_RSS_NS = {
+    "atom": "http://www.w3.org/2005/Atom",
+    "yt":   "http://www.youtube.com/xml/schemas/2015",
+}
 
 
 def discover_videos(channel_id: str, feed_name: str = "") -> list[VideoInfo]:
-    """Scrape a channel's *videos* and *streams* tabs; return video metadata.
+    """Fetch channel videos from YouTube's official Atom RSS feed.
 
-    Both tabs are fetched concurrently.  Results are merged in a fixed order
-    (videos tab first, then streams) so the returned list is stable.
+    URL: ``https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID``
 
-    Parses the ``ytInitialData`` JSON blob embedded in each tab's HTML to
-    extract the video ID, title, approximate upload date, and live status for
-    every visible video.  The simple ``videoId`` regex is also run as a
-    fallback to ensure no IDs are missed if the JSON parse fails.
+    Returns up to 15 most-recent entries (the YouTube RSS limit), newest-first.
+    No API key, no HTML parsing, and no bot-detection headers required.
 
-    Returns an ordered list of dicts (most-recent first, duplicates removed)::
+    Live streams that are still in progress will not have a transcript ready
+    yet; :func:`fetch_transcript` handles that case by returning ``None``
+    (transient failure) so the video is retried on the next run.
 
-        {"id": str, "title": str, "date": "YYYY-MM-DD", "is_live": bool}
+    Returns an ordered list of dicts::
+
+        {"id": str, "title": str, "date": "YYYY-MM-DD"}
     """
-    tabs = ["videos", "streams"]
+    url = f"https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
     prefix = f"{feed_name}: " if feed_name else ""
-
-    def _fetch_tab(tab: str) -> tuple[str, str | None]:
-        url = f"https://www.youtube.com/channel/{channel_id}/{tab}"
-        for attempt in range(3):
-            logger.debug(f"{prefix}YouTube: Fetching {tab} tab" + (f" (retry {attempt})" if attempt else ""))
-            try:
-                response = requests.get(url, headers=YOUTUBE_HEADERS, timeout=REQUEST_TIMEOUT)
-                if response.status_code == 200:
-                    return tab, response.text
-            except Exception as exc:
-                if attempt < 2:
-                    time.sleep(2 ** attempt)
-                else:
-                    logger.warning(f"{prefix}YouTube: {tab} tab failed after 3 attempts: {exc}")
-        return tab, None
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        tab_results = dict(executor.map(lambda t: _fetch_tab(t), tabs))
-
-    all_ids: list[str] = []
-    meta_lookup: dict[str, dict] = {}
-
-    for tab in tabs:
-        html = tab_results.get(tab)
-        if html is None:
+    resp = None
+    for attempt in range(3):
+        logger.debug(f"{prefix}YouTube RSS: Fetching feed" + (f" (retry {attempt})" if attempt else ""))
+        try:
+            r = requests.get(url, timeout=REQUEST_TIMEOUT)
+            if r.status_code == 200:
+                resp = r
+                break
+            logger.warning(f"{prefix}YouTube RSS: HTTP {r.status_code}")
+        except Exception as exc:
+            if attempt < 2:
+                time.sleep(2 ** attempt)
+            else:
+                logger.warning(f"{prefix}YouTube RSS: Failed after 3 attempts: {exc}")
+    if resp is None:
+        return []
+    try:
+        root = ET.fromstring(resp.text)
+    except ET.ParseError as exc:
+        logger.warning(f"{prefix}YouTube RSS: Could not parse feed XML: {exc}")
+        return []
+    videos: list[VideoInfo] = []
+    for entry in root.findall("atom:entry", _YT_RSS_NS):
+        vid_el   = entry.find("yt:videoId",    _YT_RSS_NS)
+        title_el = entry.find("atom:title",    _YT_RSS_NS)
+        pub_el   = entry.find("atom:published", _YT_RSS_NS)
+        if vid_el is None or not vid_el.text:
             continue
-        tab_meta = _parse_channel_page_metadata(html)
-        found = re.findall(r'"videoId":"([^"]{11})"', html)
-        if not found:
-            logger.warning(
-                f"{prefix}YouTube: Got 200 from {tab} tab but found 0 "
-                "video IDs — YouTube HTML structure may have changed."
-            )
-        elif not tab_meta:
-            if '"collectionThumbnailViewModel"' in html:
-                # Tab is showing playlist cards rather than individual videos
-                # (some channels organise streams this way). The regex finds
-                # false-positive IDs from playlist thumbnail URLs — skip them.
-                logger.debug(
-                    f"{prefix}YouTube: {tab} tab shows playlist cards, not "
-                    "individual videos — skipping."
-                )
-                continue
-            logger.warning(
-                f"{prefix}YouTube: Found {len(found)} video ID(s) on {tab} tab "
-                "but could not parse any titles or dates — "
-                "YouTube HTML structure may have changed "
-                f"(run: python3 helpers/dump_channel_html.py {channel_id} {tab})."
-            )
-        meta_lookup.update(tab_meta)
-        all_ids.extend(found)
-
-    today = datetime.now().strftime("%Y-%m-%d")
-    seen: dict[str, dict] = {}
-    for vid in all_ids:
-        if vid not in seen:
-            m = meta_lookup.get(vid, {})
-            seen[vid] = {
-                "id": vid,
-                "title": m.get("title") or "",
-                "date": m.get("date") or today,
-                "is_live": m.get("is_live", False),
-            }
-    return list(seen.values())
+        pub = (pub_el.text or "").strip() if pub_el is not None else ""
+        date = pub[:10] if len(pub) >= 10 else datetime.now().strftime("%Y-%m-%d")
+        videos.append({
+            "id":    vid_el.text.strip(),
+            "title": (title_el.text or "").strip() if title_el is not None else "",
+            "date":  date,
+        })
+    if not videos:
+        logger.warning(f"{prefix}YouTube RSS: Feed returned 0 entries — channel ID may be wrong")
+    return videos
 
 
 
@@ -1241,7 +1121,6 @@ def process_video(
     video_id: str,
     video_title: str,
     video_date: str,
-    is_live: bool,
     feed: FeedConfig,
     feed_dir: Path,
     supadata_client: Supadata,
@@ -1276,8 +1155,8 @@ def process_video(
                                         *transcript_rate_limit_event* has been
                                         set; caller should stop processing
                                         further videos; *n_stories* is 0.
-        ``"skipped"``                 – transcript unavailable, live stream, AI
-                                        disabled, or AI returned nothing;
+        ``"skipped"``                 – transcript unavailable, AI disabled,
+                                        or AI returned nothing;
                                         *n_stories* is 0.  When Gemini returns
                                         an empty story list, a
                                         ``metadata.json`` with
@@ -1309,9 +1188,6 @@ def process_video(
             return "transcript_quota_exhausted", 0
         counter = f" ({video_num}/{total_videos})" if total_videos else ""
         logger.info(f"{channel_name}: [{video_id}] {video_title}: TubeNews: Processing new video{counter}")
-        if is_live:
-            logger.info(f"{channel_name}: [{video_id}] {video_title}: TubeNews: Live stream — skipping, will retry next run")
-            return "skipped", 0
         logger.info(f"{channel_name}: [{video_id}] {video_title}: Supadata: Fetching transcript")
         transcript_text = fetch_transcript(
             video_id, supadata_client,
@@ -1524,7 +1400,6 @@ def process_feed(
             video_id=video_info["id"],
             video_title=video_info["title"],
             video_date=video_info["date"],
-            is_live=video_info["is_live"],
             feed=feed,
             feed_dir=feed_dir,
             supadata_client=supadata_client,

--- a/helpers/catchup.py
+++ b/helpers/catchup.py
@@ -8,12 +8,18 @@ dozens of old meetings that aren't relevant any more.
 
 How it works
 ------------
-For each configured channel, this script scrapes the ``/videos`` and
-``/streams`` tabs on YouTube and writes a minimal ``metadata.json`` stub
+For each configured channel, this script fetches YouTube's official Atom
+RSS feed and writes a minimal ``metadata.json`` stub
 (``status: "ignored_too_old"``) into a new archive directory for every
 video ID found.  TubeNews treats any directory that already contains a
 ``metadata.json`` as done and skips it, so only videos published *after*
-this script runs will be picked up by the main scraper.
+this script runs will be picked up by TubeNews.
+
+Note: YouTube's RSS feed returns the 15 most recent videos.  If a channel
+has more than 15 existing videos and you need them all marked, run this
+script as soon as possible after adding the channel — before the 16th new
+video is posted — or create stubs manually for any older video IDs you need
+to suppress.
 
 Usage::
 
@@ -23,8 +29,8 @@ Safe to re-run: videos that already have an archive directory are skipped.
 """
 
 import json
-import re
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import requests
@@ -47,11 +53,9 @@ try:
 except Exception:
     STORAGE_ROOT = BASE_DIR / "content"
 
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "Chrome/122.0.0.0 Safari/537.36"
-    )
+_YT_RSS_NS = {
+    "atom": "http://www.w3.org/2005/Atom",
+    "yt":   "http://www.youtube.com/xml/schemas/2015",
 }
 
 sys.path.insert(0, str(BASE_DIR))
@@ -66,10 +70,11 @@ from tubenews_utils import slugify  # noqa: E402
 def catchup() -> None:
     """Iterate every configured channel and stub out all visible video IDs.
 
-    For each video ID found on the channel's ``/videos`` and ``/streams``
-    tabs, a ``2000-01-01_<id>/metadata.json`` stub is created with
-    ``status: "ignored_too_old"``.  TubeNews will skip any video whose
-    archive directory already contains a ``metadata.json``.
+    Fetches YouTube's official Atom RSS feed for each channel (returns up to
+    15 most-recent videos) and creates a ``2000-01-01_<id>/metadata.json``
+    stub with ``status: "ignored_too_old"`` for each video found.  TubeNews
+    will skip any video whose archive directory already contains a
+    ``metadata.json``.
 
     Videos that already have an archive directory (from a previous run or a
     prior TubeNews session) are left untouched.
@@ -93,20 +98,21 @@ def catchup() -> None:
         feed_dir = STORAGE_ROOT / chan_slug
         feed_dir.mkdir(parents=True, exist_ok=True)
 
-        # Collect video IDs from both the /videos and /streams tabs.
+        # Fetch video IDs from the official YouTube Atom RSS feed.
         found_ids: list[str] = []
-        for tab in ("videos", "streams"):
-            url = f"https://www.youtube.com/channel/{channel_id}/{tab}"
-            try:
-                r = requests.get(url, headers=HEADERS, timeout=15)
-                r.raise_for_status()
-                found_ids.extend(re.findall(r'"videoId":"([^"]{11})"', r.text))
-            except Exception as exc:
-                print(f"    [!] Warning: could not fetch /{tab} tab: {exc}")
+        url = f"https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
+        try:
+            r = requests.get(url, timeout=15)
+            r.raise_for_status()
+            root = ET.fromstring(r.text)
+            for entry in root.findall("atom:entry", _YT_RSS_NS):
+                vid_el = entry.find("yt:videoId", _YT_RSS_NS)
+                if vid_el is not None and vid_el.text:
+                    found_ids.append(vid_el.text.strip())
+        except Exception as exc:
+            print(f"    [!] Warning: could not fetch RSS feed: {exc}")
 
-        # Deduplicate while preserving order (dict.fromkeys trick).
-        found_ids = list(dict.fromkeys(found_ids))
-        print(f"    Found {len(found_ids)} video IDs on YouTube.")
+        print(f"    Found {len(found_ids)} video IDs in RSS feed.")
 
         new_count = 0
         for v_id in found_ids:

--- a/tests/test_tubenews.py
+++ b/tests/test_tubenews.py
@@ -17,14 +17,13 @@ from TubeNews import (
     slugify,
     parse_story_file,
     process_feed,
+    discover_videos,
     rebuild_feed,
     rebuild_aggregate_feed,
     rebuild_user_feed,
     rebuild_user_blog,
     build_user_feed_xml,
     write_story_files,
-    _relative_date_to_iso,
-    _parse_channel_page_metadata,
     _resolve_early_config,
     _acquire_lock,
     _release_lock,
@@ -313,173 +312,114 @@ def test_rebuild_aggregate_feed_no_base_url_omits_self_link(multi_channel_archiv
 
 
 # ---------------------------------------------------------------------------
-# _relative_date_to_iso
+# discover_videos — RSS-based implementation
 # ---------------------------------------------------------------------------
 
-def test_relative_date_days_ago():
-    expected = (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("5 days ago") == expected
+def _make_rss_feed(entries: list[dict]) -> str:
+    """Build a minimal YouTube Atom RSS feed string for testing.
 
-def test_relative_date_singular_day():
-    expected = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("1 day ago") == expected
+    Each entry dict may have keys: video_id, title, published.
+    """
+    entry_xml = ""
+    for e in entries:
+        entry_xml += f"""
+  <entry>
+    <yt:videoId>{e['video_id']}</yt:videoId>
+    <title>{e.get('title', '')}</title>
+    <published>{e.get('published', '2026-03-15T10:30:00+00:00')}</published>
+  </entry>"""
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:yt="http://www.youtube.com/xml/schemas/2015">
+  <title>Test Channel</title>{entry_xml}
+</feed>"""
 
-def test_relative_date_weeks_ago():
-    expected = (datetime.now() - timedelta(days=14)).strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("2 weeks ago") == expected
-
-def test_relative_date_months_ago():
-    expected = (datetime.now() - timedelta(days=60)).strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("2 months ago") == expected
-
-def test_relative_date_hours_ago_returns_today():
-    # Hours map to 0 days, so result should be today.
-    expected = datetime.now().strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("3 hours ago") == expected
-
-def test_relative_date_streamed_live_exact():
-    assert _relative_date_to_iso("Streamed live on Feb 24, 2026") == "2026-02-24"
-
-def test_relative_date_streamed_live_full_month_name():
-    # YouTube uses full month names for completed livestreams, e.g. "March 25, 2026"
-    assert _relative_date_to_iso("Streamed live on March 25, 2026") == "2026-03-25"
-
-def test_relative_date_streamed_prefix():
-    # "Streamed 2 days ago" was broken because re.match anchors at start of string
-    expected = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("Streamed 2 days ago") == expected
-
-def test_relative_date_streamed_weeks():
-    expected = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("Streamed 1 week ago") == expected
-
-def test_relative_date_exact_month_day_year():
-    assert _relative_date_to_iso("Mar 14, 2026") == "2026-03-14"
-
-def test_relative_date_full_month_name():
-    assert _relative_date_to_iso("March 14, 2026") == "2026-03-14"
-
-def test_relative_date_unknown_returns_today():
-    expected = datetime.now().strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("some unrecognised format xyz") == expected
-
-def test_relative_date_empty_string_returns_today():
-    expected = datetime.now().strftime("%Y-%m-%d")
-    assert _relative_date_to_iso("") == expected
-
-
-# ---------------------------------------------------------------------------
-# _parse_channel_page_metadata
-# ---------------------------------------------------------------------------
-
-def _make_yt_html(video_obj: dict) -> str:
-    """Wrap a video renderer dict in minimal ytInitialData HTML."""
-    data = {"tabs": [video_obj]}
-    blob = json.dumps(data)
-    return f"var ytInitialData = {blob};</script>"
-
-
-def test_parse_channel_page_metadata_extracts_video():
-    video = {
-        "videoId": "abc123xyz",
-        "title": {"runs": [{"text": "Test Council Meeting"}]},
-        "publishedTimeText": {"simpleText": "5 days ago"},
-        "thumbnailOverlays": [],
-    }
-    result = _parse_channel_page_metadata(_make_yt_html(video))
-    assert "abc123xyz" in result
-    assert result["abc123xyz"]["title"] == "Test Council Meeting"
-    assert result["abc123xyz"]["is_live"] is False
-
-
-def test_parse_channel_page_metadata_simpletext_title():
-    """YouTube sometimes uses simpleText instead of runs for the title field."""
-    video = {
-        "videoId": "simple1xyzz",
-        "title": {"simpleText": "03 16 26 Joint CC & SA Meeting"},
-        "publishedTimeText": {"simpleText": "4 days ago"},
-        "thumbnailOverlays": [],
-    }
-    result = _parse_channel_page_metadata(_make_yt_html(video))
-    assert result["simple1xyzz"]["title"] == "03 16 26 Joint CC & SA Meeting"
-
-def test_parse_channel_page_metadata_no_yt_initial_data():
-    result = _parse_channel_page_metadata("<html><body>No data here</body></html>")
-    assert result == {}
-
-def test_parse_channel_page_metadata_invalid_json():
-    result = _parse_channel_page_metadata("var ytInitialData = {NOT VALID JSON};</script>")
-    assert result == {}
-
-def test_parse_channel_page_metadata_detects_live():
-    video = {
-        "videoId": "live123xyz",
-        "title": {"runs": [{"text": "Live Meeting"}]},
-        "publishedTimeText": {"simpleText": "1 minute ago"},
-        "thumbnailOverlays": [
-            {"thumbnailOverlayTimeStatusRenderer": {"style": "LIVE"}}
-        ],
-    }
-    result = _parse_channel_page_metadata(_make_yt_html(video))
-    assert result["live123xyz"]["is_live"] is True
-
-def test_parse_channel_page_metadata_detects_upcoming():
-    video = {
-        "videoId": "soon123xyz",
-        "title": {"runs": [{"text": "Upcoming Meeting"}]},
-        "publishedTimeText": {"simpleText": "1 hour ago"},
-        "thumbnailOverlays": [
-            {"thumbnailOverlayTimeStatusRenderer": {"style": "UPCOMING"}}
-        ],
-    }
-    result = _parse_channel_page_metadata(_make_yt_html(video))
-    assert result["soon123xyz"]["is_live"] is True
-
-def test_parse_channel_page_metadata_no_duplicate_ids():
-    # Same videoId appearing twice in the walk should only be recorded once.
-    video = {
-        "videoId": "dup123xyzz",
-        "title": {"runs": [{"text": "Dupe"}]},
-        "publishedTimeText": {"simpleText": "1 day ago"},
-        "thumbnailOverlays": [],
-        "nested": {
-            "videoId": "dup123xyzz",
-            "title": {"runs": [{"text": "Dupe Again"}]},
-            "thumbnailOverlays": [],
-        },
-    }
-    result = _parse_channel_page_metadata(_make_yt_html(video))
-    assert len([k for k in result if k == "dup123xyzz"]) == 1
-
-
-# ---------------------------------------------------------------------------
-# discover_videos — metadata-parse degradation warning
-# ---------------------------------------------------------------------------
 
 class _MockResponse:
-    def __init__(self, text, status_code=200):
+    def __init__(self, text="", status_code=200):
         self.text = text
         self.status_code = status_code
 
-def test_discover_videos_warns_when_ids_found_but_metadata_parse_fails(monkeypatch, caplog):
-    """When the regex finds video IDs but _parse_channel_page_metadata returns nothing,
-    discover_videos must emit a warning so silent YouTube structure changes are surfaced."""
+
+def test_discover_videos_returns_id_title_date(monkeypatch):
+    """discover_videos parses video ID, title, and ISO date from the RSS feed."""
+    import TubeNews
+    xml = _make_rss_feed([
+        {"video_id": "abc12345678", "title": "Council Meeting", "published": "2026-03-15T10:30:00+00:00"},
+    ])
+    monkeypatch.setattr(TubeNews.requests, "get", lambda *a, **kw: _MockResponse(xml))
+    results = TubeNews.discover_videos("UCtest1234567890")
+    assert len(results) == 1
+    assert results[0]["id"] == "abc12345678"
+    assert results[0]["title"] == "Council Meeting"
+    assert results[0]["date"] == "2026-03-15"
+
+
+def test_discover_videos_returns_multiple_entries(monkeypatch):
+    """discover_videos returns all entries in feed order."""
+    import TubeNews
+    xml = _make_rss_feed([
+        {"video_id": "vid111111111", "title": "Meeting 1", "published": "2026-03-20T00:00:00+00:00"},
+        {"video_id": "vid222222222", "title": "Meeting 2", "published": "2026-03-10T00:00:00+00:00"},
+    ])
+    monkeypatch.setattr(TubeNews.requests, "get", lambda *a, **kw: _MockResponse(xml))
+    results = TubeNews.discover_videos("UCtest1234567890")
+    assert [v["id"] for v in results] == ["vid111111111", "vid222222222"]
+
+
+def test_discover_videos_returns_empty_on_http_error(monkeypatch):
+    """discover_videos returns [] when the server returns a non-200 status."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews.requests, "get",
+                        lambda *a, **kw: _MockResponse(status_code=404))
+    results = TubeNews.discover_videos("UCtest1234567890")
+    assert results == []
+
+
+def test_discover_videos_returns_empty_on_malformed_xml(monkeypatch):
+    """discover_videos returns [] when the feed XML cannot be parsed."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews.requests, "get",
+                        lambda *a, **kw: _MockResponse(text="this is not xml"))
+    results = TubeNews.discover_videos("UCtest1234567890")
+    assert results == []
+
+
+def test_discover_videos_returns_empty_on_network_failure(monkeypatch):
+    """discover_videos returns [] after all retry attempts fail."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews.time, "sleep", lambda _: None)
+    monkeypatch.setattr(TubeNews.requests, "get",
+                        lambda *a, **kw: (_ for _ in ()).throw(
+                            TubeNews.requests.exceptions.ConnectionError("refused")))
+    results = TubeNews.discover_videos("UCtest1234567890")
+    assert results == []
+
+
+def test_discover_videos_warns_on_empty_feed(monkeypatch, caplog):
+    """discover_videos emits a warning when the feed has no entries."""
     import logging
     import TubeNews
-
-    # Raw HTML that contains a videoId the regex will find, but no valid ytInitialData blob.
-    bare_html = '"videoId":"abcde12345z" some other content'
-
+    empty_feed = """<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:yt="http://www.youtube.com/xml/schemas/2015">
+  <title>Empty Channel</title>
+</feed>"""
     monkeypatch.setattr(TubeNews.requests, "get",
-                        lambda *a, **kw: _MockResponse(bare_html))
-
+                        lambda *a, **kw: _MockResponse(empty_feed))
     with caplog.at_level(logging.WARNING):
         results = TubeNews.discover_videos("UCtest1234567890", feed_name="TestCh")
+    assert results == []
+    assert any("0 entries" in r.message for r in caplog.records)
 
-    assert any("titles or dates" in r.message for r in caplog.records), \
-        "Must warn when IDs are found but metadata parse returns nothing"
-    # IDs are still returned (fallback works).
-    assert any(v["id"] == "abcde12345z" for v in results)
+
+def test_discover_videos_no_is_live_field(monkeypatch):
+    """VideoInfo dicts returned by discover_videos must not contain is_live."""
+    import TubeNews
+    xml = _make_rss_feed([{"video_id": "abc12345678", "title": "T"}])
+    monkeypatch.setattr(TubeNews.requests, "get", lambda *a, **kw: _MockResponse(xml))
+    results = TubeNews.discover_videos("UCtest1234567890")
+    assert "is_live" not in results[0]
 
 
 # ---------------------------------------------------------------------------
@@ -550,9 +490,9 @@ def test_new_feed_marks_older_videos_ignored_too_old(tmp_path, monkeypatch):
 
     yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     videos = [
-        {"id": "VID_NEWEST_1", "title": "Meeting 1", "date": yesterday, "is_live": False},
-        {"id": "VID_OLDER_2", "title": "Meeting 2", "date": yesterday, "is_live": False},
-        {"id": "VID_OLDEST_3", "title": "Meeting 3", "date": yesterday, "is_live": False},
+        {"id": "VID_NEWEST_1", "title": "Meeting 1", "date": yesterday},
+        {"id": "VID_OLDER_2", "title": "Meeting 2", "date": yesterday},
+        {"id": "VID_OLDEST_3", "title": "Meeting 3", "date": yesterday},
     ]
     monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: videos)
     monkeypatch.setattr(TubeNews, "process_video", lambda **kw: ("skipped", 0))
@@ -580,8 +520,8 @@ def test_new_feed_ignored_stubs_are_idempotent(tmp_path, monkeypatch):
 
     yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     videos = [
-        {"id": "VID_NEWEST_1", "title": "Meeting 1", "date": yesterday, "is_live": False},
-        {"id": "VID_OLDER_2", "title": "Meeting 2", "date": yesterday, "is_live": False},
+        {"id": "VID_NEWEST_1", "title": "Meeting 1", "date": yesterday},
+        {"id": "VID_OLDER_2", "title": "Meeting 2", "date": yesterday},
     ]
     monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: videos)
     monkeypatch.setattr(TubeNews, "process_video", lambda **kw: ("skipped", 0))
@@ -1587,7 +1527,7 @@ def test_process_feed_processes_new_video(tmp_path, monkeypatch):
 
     yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: [
-        {"id": "VID_NEW_AAAA", "title": "Council Meeting", "date": yesterday, "is_live": False},
+        {"id": "VID_NEW_AAAA", "title": "Council Meeting", "date": yesterday},
     ])
     monkeypatch.setattr(TubeNews, "fetch_transcript",
                         lambda *a, **kw: "0:00 --> The council discussed housing.")
@@ -1626,7 +1566,7 @@ def test_process_feed_skips_video_with_no_transcript(tmp_path, monkeypatch):
 
     yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: [
-        {"id": "VID_NO_TRANS", "title": "Council Meeting", "date": yesterday, "is_live": False},
+        {"id": "VID_NO_TRANS", "title": "Council Meeting", "date": yesterday},
     ])
     monkeypatch.setattr(TubeNews, "fetch_transcript", lambda *a, **kw: None)
     gemini_called = []
@@ -1650,7 +1590,7 @@ def test_process_feed_propagates_ai_rate_limit(tmp_path, monkeypatch):
 
     yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: [
-        {"id": "VID_RATE_LIM", "title": "Council Meeting", "date": yesterday, "is_live": False},
+        {"id": "VID_RATE_LIM", "title": "Council Meeting", "date": yesterday},
     ])
     monkeypatch.setattr(TubeNews, "fetch_transcript",
                         lambda *a, **kw: "0:00 --> Transcript text.")
@@ -1673,7 +1613,7 @@ def test_process_feed_gemini_no_stories_writes_no_stories_metadata(tmp_path, mon
 
     yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: [
-        {"id": "VID_NO_STORY", "title": "Council Meeting", "date": yesterday, "is_live": False},
+        {"id": "VID_NO_STORY", "title": "Council Meeting", "date": yesterday},
     ])
     monkeypatch.setattr(TubeNews, "fetch_transcript",
                         lambda *a, **kw: "0:00 --> Transcript text.")
@@ -1940,7 +1880,6 @@ def test_process_video_writes_no_transcript_metadata(tmp_path, monkeypatch):
         video_id="VID_NO_TX",
         video_title="March Meeting",
         video_date="2026-03-01",
-        is_live=False,
         feed=feed,
         feed_dir=feed_dir,
         supadata_client=MagicMock(),
@@ -1971,8 +1910,8 @@ def test_process_feed_stops_on_transcript_quota_exhausted(tmp_path, monkeypatch)
 
     yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: [
-        {"id": "VID_A", "title": "Meeting A", "date": yesterday, "is_live": False},
-        {"id": "VID_B", "title": "Meeting B", "date": yesterday, "is_live": False},
+        {"id": "VID_A", "title": "Meeting A", "date": yesterday},
+        {"id": "VID_B", "title": "Meeting B", "date": yesterday},
     ])
 
     calls = []


### PR DESCRIPTION
discover_videos() previously scraped the /videos and /streams channel tabs, parsing the ytInitialData JSON blob embedded in each page's HTML. This required a fake browser User-Agent, was fragile to YouTube HTML changes, and needed dump_channel_html.py to diagnose breakages.

Replace with YouTube's stable official Atom feed:
  https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID

Changes:
- Rewrite discover_videos() using xml.etree.ElementTree (stdlib, no new dependency); retries up to 3× on network errors
- Remove _parse_channel_page_metadata(), _relative_date_to_iso(), YOUTUBE_HEADERS; remove timedelta import (no longer needed)
- Remove is_live from VideoInfo TypedDict and process_video() signature; live streams are handled gracefully by the existing "live streaming" error detection in fetch_transcript() (returns None → retry next run)
- Update helpers/catchup.py to use the RSS feed instead of dual-tab scrape
- Replace _parse_channel_page_metadata and _relative_date_to_iso tests with 7 new discover_videos() tests covering parse, HTTP error, malformed XML, network retry, empty feed warning, and absence of is_live field
- Remove is_live=False from all VideoInfo test fixtures
- Update CLAUDE.md: VideoInfo table, function reference, development notes

RSS returns exact ISO dates (vs approximate "N days ago") and up to 15 most-recent videos — sufficient for incremental processing. Live stream handling note added to CLAUDE.md explaining the one-extra-Supadata-call trade-off per live video per run.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN