### PR TITLE
Skip YouTube Shorts permanently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ Defined in `web/app.py`:
 
 | Function | Description |
 |---|---|
+| `_is_youtube_short(video_id)` | Returns `True` if the video is a YouTube Short by following the watch URL redirect and checking for `/shorts/` in the final URL. Fails open (returns `False`) on any network error so a transient check failure never skips a real video. |
 | `discover_videos(channel_id)` | Fetches YouTube's official Atom RSS feed (`feeds/videos.xml?channel_id=…`); returns `list[VideoInfo]` (up to 15 most-recent, exact ISO dates). Retries up to 3 times on network errors. |
 | `fetch_transcript(video_id, supadata_client, ..., transcript_rate_limit_event=None)` | Fetches timed transcript segments from Supadata; returns formatted string or None. When a quota-exhausted error is detected (HTTP 402 or `SupadataError` with a credit-related `error` code), sets `transcript_rate_limit_event` before returning None so callers can stop immediately. When Supadata raises an exception whose message contains `"live streaming"`, returns `None` (transient) so the video is retried next run without being permanently marked. |
 
@@ -287,7 +288,7 @@ Story body text in AP inverted pyramid style...
 }
 ```
 
-`status` values: `"processed"` | `"ignored_too_old"` | `"no_stories"` (AI ran but returned no relevant stories) | `"no_transcript_available"` (Supadata confirmed no captions exist; will not be retried)
+`status` values: `"processed"` | `"ignored_too_old"` | `"ignored_short"` (video is a YouTube Short; will not be retried) | `"no_stories"` (AI ran but returned no relevant stories) | `"no_transcript_available"` (Supadata confirmed no captions exist; will not be retried)
 
 `processed_focuses` is a sorted list of all focus strings for which Gemini has been called on this video. Old `metadata.json` files that pre-date this field have no `processed_focuses` key and are treated as fully processed (not re-run).
 

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -327,6 +327,28 @@ _YT_RSS_NS = {
 }
 
 
+def _is_youtube_short(video_id: str, feed_name: str = "") -> bool:
+    """Return True if *video_id* is a YouTube Short.
+
+    Makes a GET request (with redirect-following) to the standard watch URL.
+    If YouTube redirects to a ``/shorts/`` URL the video is a Short and should
+    be skipped — Shorts are rarely longer than 60 seconds and are unlikely to
+    contain the kind of substantive content TubeNews is designed to process.
+
+    Fails open: returns ``False`` on any network or HTTP error so a transient
+    failure never causes a real meeting video to be permanently skipped.
+    """
+    watch_url = f"https://www.youtube.com/watch?v={video_id}"
+    prefix = f"{feed_name}: " if feed_name else ""
+    try:
+        with requests.get(watch_url, allow_redirects=True, stream=True,
+                          timeout=REQUEST_TIMEOUT) as resp:
+            return "/shorts/" in resp.url
+    except Exception as exc:
+        logger.debug(f"{prefix}[{video_id}] Short check failed (treating as non-Short): {exc}")
+        return False
+
+
 def discover_videos(channel_id: str, feed_name: str = "") -> list[VideoInfo]:
     """Fetch channel videos from YouTube's official Atom RSS feed.
 
@@ -1188,6 +1210,17 @@ def process_video(
             return "transcript_quota_exhausted", 0
         counter = f" ({video_num}/{total_videos})" if total_videos else ""
         logger.info(f"{channel_name}: [{video_id}] {video_title}: TubeNews: Processing new video{counter}")
+        if _is_youtube_short(video_id, feed_name=channel_name):
+            logger.info(f"{channel_name}: [{video_id}] {video_title}: TubeNews: YouTube Short — skipping permanently")
+            short_dir = feed_dir / f"{video_date}_{video_id}"
+            short_dir.mkdir(exist_ok=True)
+            (short_dir / "metadata.json").write_text(json.dumps({
+                "video_id": video_id,
+                "video_title": video_title,
+                "status": "ignored_short",
+                "processed_at": time.time(),
+            }))
+            return "skipped", 0
         logger.info(f"{channel_name}: [{video_id}] {video_title}: Supadata: Fetching transcript")
         transcript_text = fetch_transcript(
             video_id, supadata_client,

--- a/tests/test_tubenews.py
+++ b/tests/test_tubenews.py
@@ -1902,6 +1902,133 @@ def test_process_video_writes_no_transcript_metadata(tmp_path, monkeypatch):
     assert not _needs_processing("VID_NO_TX", feed_dir)
 
 
+# ---------------------------------------------------------------------------
+# _is_youtube_short / Shorts filtering
+# ---------------------------------------------------------------------------
+
+def test_is_youtube_short_returns_true_on_shorts_redirect(monkeypatch):
+    """_is_youtube_short returns True when YouTube redirects to /shorts/ URL."""
+    import TubeNews
+
+    class _ShortResp:
+        url = "https://www.youtube.com/shorts/abc12345678"
+        def __enter__(self): return self
+        def __exit__(self, *_): pass
+
+    monkeypatch.setattr(TubeNews.requests, "get", lambda *a, **kw: _ShortResp())
+    assert TubeNews._is_youtube_short("abc12345678") is True
+
+
+def test_is_youtube_short_returns_false_for_normal_video(monkeypatch):
+    """_is_youtube_short returns False when the URL stays on /watch."""
+    import TubeNews
+
+    class _WatchResp:
+        url = "https://www.youtube.com/watch?v=abc12345678"
+        def __enter__(self): return self
+        def __exit__(self, *_): pass
+
+    monkeypatch.setattr(TubeNews.requests, "get", lambda *a, **kw: _WatchResp())
+    assert TubeNews._is_youtube_short("abc12345678") is False
+
+
+def test_is_youtube_short_fails_open_on_network_error(monkeypatch):
+    """_is_youtube_short returns False (fail open) on any exception."""
+    import TubeNews
+    monkeypatch.setattr(TubeNews.requests, "get",
+                        lambda *a, **kw: (_ for _ in ()).throw(
+                            TubeNews.requests.exceptions.ConnectionError("refused")))
+    assert TubeNews._is_youtube_short("abc12345678") is False
+
+
+def test_process_video_skips_shorts_permanently(tmp_path, monkeypatch):
+    """When _is_youtube_short returns True, process_video writes ignored_short metadata."""
+    import json as _json
+    import TubeNews
+    from TubeNews import _needs_processing
+
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+    monkeypatch.setattr(TubeNews, "_is_youtube_short", lambda *a, **kw: True)
+
+    feed = {"channel_id": "UCtest1234", "channel_name": "Test Channel", "focus": "housing"}
+    feed_dir = tmp_path / "test_channel"
+    feed_dir.mkdir()
+
+    from unittest.mock import MagicMock
+    status, n = TubeNews.process_video(
+        video_id="SHORT1234567",
+        video_title="Short Dance Video",
+        video_date="2026-03-01",
+        feed=feed,
+        feed_dir=feed_dir,
+        supadata_client=MagicMock(),
+        config={"gemini_api_key": "k", "gemini_model": "m"},
+        ai_disabled=False,
+    )
+    assert status == "skipped"
+    assert n == 0
+
+    meeting_dirs = [d for d in feed_dir.iterdir() if d.is_dir() and "SHORT1234567" in d.name]
+    assert len(meeting_dirs) == 1
+    meta = _json.loads((meeting_dirs[0] / "metadata.json").read_text())
+    assert meta["status"] == "ignored_short"
+    assert not _needs_processing("SHORT1234567", feed_dir)
+
+
+def test_process_video_short_check_not_called_for_cached_transcript(tmp_path, monkeypatch):
+    """When a cached transcript exists, the Shorts check is bypassed."""
+    import TubeNews
+
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+    short_check_calls = []
+    monkeypatch.setattr(TubeNews, "_is_youtube_short",
+                        lambda *a, **kw: short_check_calls.append(1) or True)
+    monkeypatch.setattr(TubeNews, "call_gemini_api", lambda *a, **kw: [])
+
+    feed = {"channel_id": "UCtest1234", "channel_name": "Test Channel", "focus": "housing"}
+    feed_dir = tmp_path / "test_channel"
+    # Pre-create a meeting dir with a transcript (simulates partial previous run).
+    meeting_dir = feed_dir / "2026-03-01_VID_CACHED"
+    meeting_dir.mkdir(parents=True)
+    (meeting_dir / "transcript.txt").write_text("0s --> Some content")
+
+    from unittest.mock import MagicMock
+    TubeNews.process_video(
+        video_id="VID_CACHED",
+        video_title="Cached Meeting",
+        video_date="2026-03-01",
+        feed=feed,
+        feed_dir=feed_dir,
+        supadata_client=MagicMock(),
+        config={"gemini_api_key": "k", "gemini_model": "m"},
+        ai_disabled=False,
+    )
+    assert short_check_calls == [], "Short check must not be called when transcript is cached"
+
+
+def test_process_feed_skips_short_video(tmp_path, monkeypatch):
+    """process_feed marks a Short as ignored_short and reports 0 stories."""
+    import TubeNews
+
+    monkeypatch.setattr(TubeNews, "STORAGE_ROOT", tmp_path)
+    yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    monkeypatch.setattr(TubeNews, "discover_videos", lambda *a, **kw: [
+        {"id": "SHORT1234567", "title": "Cool Short", "date": yesterday},
+    ])
+    monkeypatch.setattr(TubeNews, "_is_youtube_short", lambda *a, **kw: True)
+    fetch_calls = []
+    monkeypatch.setattr(TubeNews, "fetch_transcript",
+                        lambda *a, **kw: fetch_calls.append(1) or "transcript")
+
+    from unittest.mock import MagicMock
+    feed = {"channel_id": "UCtest1234567890", "channel_name": "Test Channel", "focus": "test"}
+    _, _, stories_written = process_feed(
+        feed, MagicMock(), {"gemini_api_key": "k", "gemini_model": "m"}, None
+    )
+    assert stories_written == 0
+    assert fetch_calls == [], "Supadata must not be called for a Short"
+
+
 def test_process_feed_stops_on_transcript_quota_exhausted(tmp_path, monkeypatch):
     """process_feed must stop processing further videos once transcript quota is exhausted."""
     import threading


### PR DESCRIPTION
Adds _is_youtube_short() which follows the watch URL redirect: if YouTube redirects to /shorts/<id>, the video is a Short and should be skipped. Shorts are too brief to contain substantive meeting content.

On detection, process_video() writes a metadata.json stub with status: "ignored_short" so the video is never retried, then returns "skipped". The check only runs for genuinely new videos — if a cached transcript already exists (partial previous run), the check is bypassed to avoid blocking AI re-processing.

The check fails open: any network error returns False so a transient failure never causes a real meeting video to be permanently skipped.

New status value: "ignored_short" added to CLAUDE.md and metadata schema.

6 new tests: redirect → True, no redirect → False, network error → False, process_video writes ignored_short, cached transcript bypasses check, process_feed skips Short without calling Supadata.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN