### PR TITLE
Add /youtube/push proxy block to nginx config for WebSub daemon

### DIFF
--- a/SERVING.md
+++ b/SERVING.md
@@ -364,14 +364,19 @@ Add a location block to your existing TubeNews nginx config:
 
 ```nginx
 location /youtube/push {
-    proxy_pass http://127.0.0.1:8675;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_pass         http://10.0.0.1:8675;
+    proxy_set_header   Host              $host;
+    proxy_set_header   X-Real-IP         $remote_addr;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_read_timeout 30s;
 }
 ```
 
-The path in the `location` block must match the path component of
-`websub_callback_url` in `TubeNews.json`.
+Replace `10.0.0.1` with the jail IP if yours differs. The path in the
+`location` block must match the path component of `websub_callback_url` in
+`TubeNews.json`. The block is already included in
+`contrib/nginx/tubenews.org.conf`.
 
 ### Subscriptions
 

--- a/contrib/nginx/tubenews.org.conf
+++ b/contrib/nginx/tubenews.org.conf
@@ -8,6 +8,7 @@
 #   certbot --nginx -d tubenews.org -d www.tubenews.org
 #
 # TubeNews (gunicorn) runs inside the Bastille jail at 10.0.0.1:8000.
+# The WebSub daemon (--daemon mode) listens on 10.0.0.1:8675.
 # Flask handles all /content/ serving — nginx proxies everything.
 
 # www → apex redirect
@@ -23,6 +24,17 @@ server {
     listen 80;
     listen [::]:80;
     server_name tubenews.org;
+
+    # WebSub push endpoint — YouTube's hub sends GET (challenge) and POST
+    # (notifications) here.  The TubeNews daemon receives them on port 8675.
+    location /youtube/push {
+        proxy_pass         http://10.0.0.1:8675;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+    }
 
     location / {
         proxy_pass         http://10.0.0.1:8000;


### PR DESCRIPTION
The WebSub receiver runs on port 8675 inside the jail (separate from gunicorn on 8000). nginx needs a dedicated location block to forward YouTube hub requests (both GET challenges and POST notifications) to that port.

Update SERVING.md reverse proxy snippet to use the jail IP (10.0.0.1) and full headers to match the contrib config.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN