### PR TITLE
Fix deploy.sh to preserve state/ directory

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -34,6 +34,7 @@ echo "Deploying $SRC → $DEST"
 rsync -av --delete \
     --exclude='TubeNews.json' \
     --exclude='content/' \
+    --exclude='state/' \
     --exclude='deploy.sh' \
     --exclude='.git/' \
     --exclude='.gitignore' \


### PR DESCRIPTION
rsync --delete was wiping state/ (users, channels.json, run_logs, etc.) because that directory is gitignored and absent from the dev tree.

https://claude.ai/code/session_019Pdm39GB4mgrykKh4zo8xN