### PR TITLE
fix(web): remove IANA timezone name from published timestamp display

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -459,7 +459,7 @@ def _reformat_published_timestamp(published_str: str, user_timezone: str, server
         formatted_time = _fmt_no_leading_zeros(user_dt, "%I:%M %p")
         tz_abbr = user_dt.strftime("%Z")
 
-        return f"{formatted_date} at {formatted_time} {tz_abbr} ({user_timezone})"
+        return f"{formatted_date} at {formatted_time} {tz_abbr}"
     except Exception:
         return published_str
 


### PR DESCRIPTION
"Published April 9, 2026 at 02:10 PM PDT (America/Los_Angeles)" → "Published April 9, 2026 at 02:10 PM PDT"

https://claude.ai/code/session_01WxK99Ubahhdm2qscEZdGjy