### PR TITLE
Add daily email digest via Resend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,10 @@ Defined in `web/app.py`:
 | `_next_transcript_try(queued_at_iso, attempt)` | Returns the ISO 8601 UTC timestamp for the next transcript fetch attempt, computed as `queued_at + _TRANSCRIPT_RETRY_OFFSETS[attempt]`. Clamps `attempt` to the last table entry. Falls back to `now()` if `queued_at_iso` is malformed. |
 | `_write_no_transcript_metadata(video_id, feed_dir, video_date, video_title, skip_reason)` | Creates the meeting directory if needed and writes `metadata.json` with `status = "no_transcript_available"`. Called from `process_video` (48h age path) and from the WebSub processor (12-attempt exhaustion path). |
 | `_wsb_try_fetch_transcript(entry, feed_cfg, supadata_client, transcript_rate_limit_event)` | Phase-1 helper for the WebSub processor. Checks for a cached `transcript.txt`; if absent, calls `fetch_transcript()` and caches the result. Returns one of `"cached"`, `"success"`, `"transient"`, `"permanent"`, `"livestream"`, or `"quota_exhausted"`. Never runs Gemini. |
+| `_iter_all_users()` | Generator; yields each user's raw data dict from `state/users/*/user.json`. Adds `_uid` (UUID dir name) and `_user_dir` (`Path`) keys. Silently skips unreadable or malformed files. Used by `_send_daily_digests`. |
+| `_scan_stories_since(user_data, user_id, cutoff_ts)` | Scans `content/` for stories from channels in `user_data["channels"]` whose `processed_at > cutoff_ts`. Respects `**Users:**` attribution (same logic as `_get_user_stories`). Returns a list of lightweight dicts: `title`, `channel_name`, `video_id`, `start_seconds`. Sorted newest-first. |
+| `_build_digest_html(name, email, stories, feed_url, base_url)` | Builds the HTML email body for a daily digest. *feed_url* must be an absolute URL; each story links to `feed_url#s<video_id>-<start_seconds>`. Returns an HTML string safe for use as the Resend `html` parameter. |
+| `_send_daily_digests(config)` | Sends morning digest emails to opted-in users via Resend. Skips silently when `resend_api_key` or `base_url` is absent. For each user with `digest_email_enabled=true`, calls `_scan_stories_since` using `last_digest_sent` as the cutoff (or `now - 24h` if absent), sends via `resend.Emails.send()`, and atomically writes `last_digest_sent` to `user.json`. |
 
 ### YouTube data-gathering
 
@@ -365,6 +369,9 @@ The queue stores videos sent by YouTube's WebSub hub, pending processing. Each e
 | `gemini_call_delay` | No | Minimum seconds between any two Gemini API calls, enforced globally via a lock (default: `8`). Applies across focus passes and across different videos so the free-tier 15 RPM limit is never exceeded regardless of backlog size. At 8 s the effective rate is ~7.5 RPM. Set to `0` to disable (not recommended). |
 | `base_url` | No | Public URL of `content/rss.xml`, used as the aggregate feed self-link |
 | `ntfy_topic` | No | ntfy.sh topic for run-summary push notifications (e.g. `"TubeNewsAdmin"`); omit to disable |
+| `resend_api_key` | No | Resend API key for daily email digests; omit to disable digest sending |
+| `resend_from_email` | No | "From" address for digest emails (must be a verified Resend sender, e.g. `"TubeNews <digest@yourdomain.com>"`); defaults to `"TubeNews <noreply@example.com>"` |
+| `email_digest_send_hour` | No | UTC hour (0–23) at which the daemon sends daily digests (default: `7`). The daemon fires at the first processor cycle within that hour. Requires `base_url` to be set. |
 | `max_parallel_feeds` | No | Max channels processed concurrently (default: `1`; capped at number of feeds). Keep at `1` unless you have a paid Gemini tier with higher RPM limits. |
 | `port` | No | Port the Flask web UI listens on (default: `8000`) |
 | `tubenews_key` | Web UI only | Flask session secret key — generate with `python -c 'import secrets; print(secrets.token_hex(32))'`; also readable from `TUBENEWS_SECRET_KEY` env var |
@@ -384,6 +391,7 @@ When running in daemon mode (the default, `python3 TubeNews.py`), the following 
 - `gemini_api_key`, `supadata_api_key` — next API call uses new key
 - `request_timeout` — applied immediately via `socket.setdefaulttimeout()`
 - `gemini_call_delay`, `gemini_model` — picked up by next processing cycle
+- `resend_api_key`, `resend_from_email`, `email_digest_send_hour` — picked up by next processor cycle
 - `base_url`, `ntfy_topic` — used at next web request
 - `websub_check_interval_minutes`, `websub_max_videos_per_cycle` — applied next cycle
 - `websub_min_age_minutes` — deprecated (logs warning if present; has no effect)
@@ -416,9 +424,9 @@ pytest tests/ -v
 
 | File | Covers |
 |---|---|
-| `tests/test_tubenews.py` | `slugify`, `parse_story_file` (including `topics`, `user_ids`, and HTML escaping in `body_html`), `_story_matches_focus`, `write_story_files` (including `**Users:**` output), `_collect_channel_focuses` (tuple return type, user-id merging), `discover_videos` (RSS parse, HTTP error, malformed XML, network retry, empty feed warning, no `is_live` field), `fetch_transcript` (success path, language mismatch, live-stream skip, quota exhaustion + event flag), the JSON extraction regex in `call_gemini_api`, `rebuild_feed`, `rebuild_aggregate_feed`, `build_user_feed_xml`, lock/unlock helpers, config resolution, `_recover_orphaned_videos` (queues dirs without metadata, skips dirs with metadata, skips already-queued, skips missing channel.json, returns count) |
+| `tests/test_tubenews.py` | `slugify`, `parse_story_file` (including `topics`, `user_ids`, and HTML escaping in `body_html`), `_story_matches_focus`, `write_story_files` (including `**Users:**` output), `_collect_channel_focuses` (tuple return type, user-id merging), `discover_videos` (RSS parse, HTTP error, malformed XML, network retry, empty feed warning, no `is_live` field), `fetch_transcript` (success path, language mismatch, live-stream skip, quota exhaustion + event flag), the JSON extraction regex in `call_gemini_api`, `rebuild_feed`, `rebuild_aggregate_feed`, `build_user_feed_xml`, lock/unlock helpers, config resolution, `_recover_orphaned_videos` (queues dirs without metadata, skips dirs with metadata, skips already-queued, skips missing channel.json, returns count), `_iter_all_users` (yields user data, skips malformed), `_scan_stories_since` (returns recent stories, excludes old/unsubscribed), `_build_digest_html` (anchor links, HTML escaping), `_send_daily_digests` (skips no api key, skips no base_url, skips opted-out, sends to opted-in, filters old stories) |
 | `tests/test_web.py` | `web/app.py` URL helpers (`_rss_url`, `_feed_url`), user preferences |
-| `tests/test_webapp.py` | Flask routes: login guards, rate-limit (429 after 10 attempts), locked-account rejection, dashboard subscription save, admin guards, public token routes, lock-file detection, run-now trigger, channel browse YouTube link, admin runs channel links |
+| `tests/test_webapp.py` | Flask routes: login guards, rate-limit (429 after 10 attempts), locked-account rejection, dashboard subscription save, admin guards, public token routes, lock-file detection, run-now trigger, channel browse YouTube link, admin runs channel links, `digest_email_enabled` preference save (checked and unchecked) |
 
 All tests use `tmp_path` fixtures — no network calls and no real archive needed. For functions that hit external APIs (`fetch_transcript`, `call_gemini_api`), use `monkeypatch` or `unittest.mock.patch`.
 
@@ -486,7 +494,8 @@ state/users/
   "last_accessed": "2026-04-07T00:14:36Z",
   "locked": false,
   "feed_name": "Alice's Local News",
-  "preferences": {"dark_mode": false, "font_size": "normal", "timezone": "America/Los_Angeles"},
+  "preferences": {"dark_mode": false, "font_size": "normal", "timezone": "America/Los_Angeles", "digest_email_enabled": true},
+  "last_digest_sent": "2026-04-09T07:00:00Z",
   "seen_channel_ids": ["UCxxxxxxx", "UCyyyyyyy"],
   "read_articles": ["abc123hash", "def456hash"],
   "starred_articles": ["abc123hash"],
@@ -500,7 +509,8 @@ state/users/
 - `feed_token` — UUID generated at registration; authenticates all public (no-login) URLs for that user. Rotating it invalidates both the RSS feed URL and the feed page URL simultaneously.
 - `locked` — boolean; when `true` the account fails `is_active` and is rejected by flask-login on every request without needing to log out. Admin-toggled via `/admin/user/<uid>/lock`.
 - `feed_name` — optional custom title shown on the user's `/feed` page (e.g. `"Alice's Local News"`). Key absent means the default `"<name>'s TubeNews"` title is used.
-- `preferences` — display settings dict with keys `dark_mode` (bool), `font_size` (`"normal"` | `"large"` | `"larger"`), and `timezone` (IANA timezone string, optional). `dark_mode` and `font_size` converted to CSS classes by `_prefs_to_classes()` and applied to `<html>` via the `inject_body_classes` context processor. `timezone` controls display of timestamps in the web UI (admin pages, story published times). Defaults to UTC if not set (since all stored data is in UTC). Key absent means all defaults (light mode, normal font, UTC display).
+- `preferences` — display settings dict with keys `dark_mode` (bool), `font_size` (`"normal"` | `"large"` | `"larger"`), `timezone` (IANA timezone string, optional), and `digest_email_enabled` (bool, optional). `dark_mode` and `font_size` converted to CSS classes by `_prefs_to_classes()` and applied to `<html>` via the `inject_body_classes` context processor. `timezone` controls display of timestamps in the web UI (admin pages, story published times). Defaults to UTC if not set (since all stored data is in UTC). `digest_email_enabled` opts the user into daily email digests via Resend (requires `resend_api_key` and `base_url` in `TubeNews.json`). Key absent means all defaults (light mode, normal font, UTC display, no digest).
+- `last_digest_sent` — ISO 8601 UTC timestamp in `YYYY-MM-DDTHH:MM:SSZ` format of the most recent successful digest email send. Written atomically by `_send_daily_digests` immediately after `resend.Emails.send()` succeeds. Key absent means no digest has been sent yet (first send uses `now - 24h` as the cutoff).
 - `seen_channel_ids` — list of channel IDs the user has "seen" on the dashboard. The `inject_body_classes` context processor diffs this against the current feed list to compute `unseen_channel_count`, which drives the red badge on the "Settings" nav link. Key absent means not yet initialised (pre-feature users); treated as 0 unseen so existing users aren't badged on upgrade. Written (covering all current channels) whenever the user loads or saves the dashboard.
 - `read_articles` — sorted list of `content_hash` strings for articles the user has marked as read. `/feed` (Unread tab) hides stories whose hash is in this list; `/read` (Read tab) shows only those stories. Key absent means no articles have been read. Written by the `account_mark_read`, `account_mark_unread`, `account_mark_all_read`, and `account_mark_all_unread` routes. Growth is bounded (~117 KB/year at 10 stories/day × 32 bytes/hash) and individual unread is preserved.
 - `starred_articles` — sorted list of `content_hash` strings for articles the user has starred. `/starred` shows only these stories. Key absent means no starred articles. Written by the `account_mark_starred` and `account_mark_unstarred` routes. Independent of read/unread state.

--- a/TubeNews.json.sample
+++ b/TubeNews.json.sample
@@ -20,6 +20,10 @@
 
   "ntfy_topic": "TubeNewsAdmin",
 
+  "resend_api_key": "",
+  "resend_from_email": "TubeNews <digest@yourdomain.com>",
+  "email_digest_send_hour": 7,
+
   "websub_callback_url": "https://yourdomain.com/youtube/push",
   "websub_secret": "generate with: python3 -c 'import secrets; print(secrets.token_hex(32))'",
   "websub_daemon_port": 8675,

--- a/TubeNews.py
+++ b/TubeNews.py
@@ -32,7 +32,7 @@ import time
 import xml.etree.ElementTree as ET
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import TypedDict
+from typing import Iterator, TypedDict
 
 # ---------------------------------------------------------------------------
 # Third-party imports
@@ -2779,6 +2779,7 @@ def _wsb_processor_thread(config: dict) -> None:
     except Exception as exc:
         logger.warning(f"WebSub processor: orphan recovery failed: {exc}")
     _last_orphan_recovery: float = time.time()
+    _last_digest_check: float = 0.0
 
     while True:
         # -- Config reload ----------------------------------------------------
@@ -2827,6 +2828,16 @@ def _wsb_processor_thread(config: dict) -> None:
             except Exception as exc:
                 logger.warning(f"WebSub processor: orphan recovery failed: {exc}")
             _last_orphan_recovery = time.time()
+
+        # -- Daily email digest -----------------------------------------------
+        digest_send_hour = int(current_config.get("email_digest_send_hour", 7))
+        if (datetime.utcnow().hour == digest_send_hour
+                and time.time() - _last_digest_check >= _SECONDS_PER_DAY):
+            try:
+                _send_daily_digests(current_config)
+            except Exception as exc:
+                logger.warning(f"Daily digest: unexpected error: {exc}")
+            _last_digest_check = time.time()
 
         # -- Queue processing -------------------------------------------------
         ripe = _read_push_queue()
@@ -3265,6 +3276,212 @@ def _run_daemon(config: dict) -> None:
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
+
+def _iter_all_users() -> Iterator[dict]:
+    """Yield each user's raw data dict (from state/users/*/user.json).
+
+    Yields dicts with an extra ``_uid`` key containing the UUID directory name.
+    Skips unreadable or malformed files silently.
+    """
+    users_dir = STATE_ROOT / "users"
+    if not users_dir.is_dir():
+        return
+    for user_dir in users_dir.iterdir():
+        if not user_dir.is_dir():
+            continue
+        user_json = user_dir / "user.json"
+        if not user_json.exists():
+            continue
+        try:
+            data = json.loads(user_json.read_text(encoding="utf-8"))
+            data["_uid"] = user_dir.name
+            data["_user_dir"] = user_dir
+            yield data
+        except Exception:
+            continue
+
+
+def _scan_stories_since(user_data: dict, user_id: str, cutoff_ts: float) -> list[dict]:
+    """Return story dicts (title, channel_name, video_id, start_seconds) for
+    stories that are newer than *cutoff_ts* and visible to *user_id*.
+
+    Only scans subscribed channels.  Respects ``**Users:**`` attribution.
+    Results are sorted newest-first.
+    """
+    subscribed = set(user_data.get("channels", {}).keys())
+    raw: list[dict] = []
+    for channel_dir in STORAGE_ROOT.iterdir():
+        if not channel_dir.is_dir() or channel_dir.name.startswith("_"):
+            continue
+        channel_json = channel_dir / "channel.json"
+        if not channel_json.exists():
+            continue
+        try:
+            ch = json.loads(channel_json.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if ch.get("channel_id") not in subscribed:
+            continue
+        channel_name = ch.get("channel_name", channel_dir.name.replace("_", " "))
+        for meeting_dir in channel_dir.iterdir():
+            if not meeting_dir.is_dir():
+                continue
+            meta_path = meeting_dir / "metadata.json"
+            if not meta_path.exists():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+                if meta.get("status") == "ignored_too_old":
+                    continue
+                proc_at = _get_timestamp_as_float(meta.get("processed_at"))
+                if proc_at <= cutoff_ts:
+                    continue
+                for story_file in sorted(meeting_dir.glob("[0-9]*.md")):
+                    raw.append({"file": story_file, "meta": meta,
+                                "channel_name": channel_name,
+                                "processed_at": proc_at})
+            except Exception:
+                continue
+    raw.sort(key=lambda e: e["processed_at"], reverse=True)
+
+    stories = []
+    for entry in raw:
+        try:
+            s = parse_story_file(entry["file"])
+            story_user_ids = s.get("user_ids", [])
+            if story_user_ids and user_id not in story_user_ids:
+                continue
+            stories.append({
+                "title": s["title"],
+                "channel_name": entry["channel_name"],
+                "video_id": entry["meta"]["video_id"],
+                "start_seconds": s["start_seconds"],
+            })
+        except Exception:
+            continue
+    return stories
+
+
+def _build_digest_html(name: str, email: str, stories: list[dict], feed_url: str, base_url: str) -> str:
+    """Build the HTML body for a daily digest email.
+
+    *feed_url* must be an absolute URL (``base_url`` + ``/feed/<token>.html``).
+    Each story links to ``feed_url#s<video_id>-<start_seconds>``.
+    """
+    import html as _html
+    account_url = base_url.rstrip("/") + "/account" if base_url else ""
+    story_items = []
+    for s in stories:
+        anchor = f"s{s['video_id']}-{s['start_seconds']}"
+        href = f"{feed_url}#{anchor}"
+        title_escaped = _html.escape(s["title"])
+        channel_escaped = _html.escape(s["channel_name"])
+        story_items.append(
+            f'<li style="margin-bottom:0.5em">'
+            f'<a href="{href}" style="color:#1a73e8;text-decoration:none">{title_escaped}</a>'
+            f' <span style="color:#666;font-size:0.9em">— {channel_escaped}</span>'
+            f"</li>"
+        )
+    items_html = "\n".join(story_items)
+    story_count = len(stories)
+    story_word = "story" if story_count == 1 else "stories"
+    footer = (
+        f'<p style="color:#888;font-size:0.85em;margin-top:2em">'
+        f"You're receiving this because you enabled daily email digests in TubeNews."
+    )
+    if account_url:
+        footer += (
+            f' <a href="{account_url}" style="color:#888">Manage preferences</a>.'
+        )
+    footer += "</p>"
+    return f"""<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:Georgia,serif;max-width:600px;margin:0 auto;padding:1.5em;color:#111">
+  <p>Hi {_html.escape(name)}, here are your {story_count} new {story_word} from TubeNews:</p>
+  <ul style="padding-left:1.2em;line-height:1.7">
+{items_html}
+  </ul>
+  <p><a href="{feed_url}" style="color:#1a73e8">Open your full feed</a></p>
+  <hr style="border:none;border-top:1px solid #ddd;margin:2em 0">
+  {footer}
+</body>
+</html>"""
+
+
+def _send_daily_digests(config: dict) -> None:
+    """Send morning digest emails to opted-in users via Resend.
+
+    Skips silently if ``resend_api_key`` is absent or ``base_url`` is not
+    configured (relative URLs are unusable in email clients).
+    """
+    api_key = config.get("resend_api_key", "").strip()
+    if not api_key:
+        return
+    base_url = config.get("base_url", "").rstrip("/")
+    if not base_url:
+        logger.warning("Daily digest: base_url is not set in TubeNews.json — digest skipped (email links require an absolute URL)")
+        return
+    from_email = config.get("resend_from_email", "TubeNews <noreply@example.com>")
+
+    try:
+        import resend as _resend
+    except ImportError:
+        logger.warning("Daily digest: 'resend' package not installed — run: pip install resend")
+        return
+
+    _resend.api_key = api_key
+
+    sent = 0
+    for user_data in _iter_all_users():
+        if not user_data.get("preferences", {}).get("digest_email_enabled"):
+            continue
+        email = user_data.get("email", "")
+        name = user_data.get("name", email)
+        feed_token = user_data.get("feed_token", "")
+        user_id = user_data.get("_uid", "")
+        if not email or not feed_token:
+            continue
+
+        last_sent_iso = user_data.get("last_digest_sent")
+        cutoff_ts: float
+        if last_sent_iso:
+            parsed = iso8601_to_unix(last_sent_iso)
+            cutoff_ts = parsed if parsed is not None else time.time() - _SECONDS_PER_DAY
+        else:
+            cutoff_ts = time.time() - _SECONDS_PER_DAY
+
+        stories = _scan_stories_since(user_data, user_id, cutoff_ts)
+        if not stories:
+            continue
+
+        feed_url = f"{base_url}/feed/{feed_token}.html"
+        html_body = _build_digest_html(name, email, stories, feed_url, base_url)
+        story_count = len(stories)
+        story_word = "story" if story_count == 1 else "stories"
+        try:
+            _resend.Emails.send({
+                "from": from_email,
+                "to": [email],
+                "subject": f"Your TubeNews digest \u2014 {story_count} new {story_word}",
+                "html": html_body,
+            })
+            # Update last_digest_sent in user.json
+            user_dir: Path = user_data["_user_dir"]
+            user_json_path = user_dir / "user.json"
+            raw = json.loads(user_json_path.read_text(encoding="utf-8"))
+            raw["last_digest_sent"] = now_utc_iso()
+            tmp = user_json_path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(raw, indent=2), encoding="utf-8")
+            tmp.rename(user_json_path)
+            logger.info(f"Daily digest sent to {email} ({story_count} {story_word})")
+            sent += 1
+        except Exception as exc:
+            logger.warning(f"Daily digest: failed to send to {email}: {exc}")
+
+    if sent:
+        logger.info(f"Daily digest: sent to {sent} user{'s' if sent != 1 else ''}")
 
 
 def _send_ntfy(topic: str, total_stories: int, feed_results: list[FeedResult], started_at: float) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ flask-limiter
 gunicorn
 pytz
 limits
+resend

--- a/tests/test_tubenews.py
+++ b/tests/test_tubenews.py
@@ -3278,3 +3278,298 @@ def test_processor_does_not_defer_past_scheduled_start(tmp_path, monkeypatch):
     result = TubeNews._wsb_try_fetch_transcript(entry, feed_cfg, None, None)
     assert result == "success"
     assert fetch_called == ["past_sched_vid"]
+
+
+# ---------------------------------------------------------------------------
+# Daily digest helpers: _iter_all_users, _scan_stories_since,
+#                       _build_digest_html, _send_daily_digests
+# ---------------------------------------------------------------------------
+
+import TubeNews as _tn_digest
+
+
+def _make_digest_user(users_root: Path, uid: str, email: str, channels: dict,
+                      token: str = "tok123", digest_enabled: bool = True,
+                      last_digest_sent: str | None = None) -> Path:
+    """Write a minimal user.json under users_root/<uid>/."""
+    from werkzeug.security import generate_password_hash
+    user_dir = users_root / uid
+    user_dir.mkdir(parents=True, exist_ok=True)
+    data: dict = {
+        "name": "Test User",
+        "email": email,
+        "password_hash": generate_password_hash("testpassword123"),
+        "channels": channels,
+        "feed_token": token,
+        "preferences": {"digest_email_enabled": digest_enabled},
+    }
+    if last_digest_sent is not None:
+        data["last_digest_sent"] = last_digest_sent
+    (user_dir / "user.json").write_text(json.dumps(data), encoding="utf-8")
+    return user_dir
+
+
+def _make_digest_channel(storage_root: Path, slug: str, channel_id: str,
+                         channel_name: str, video_id: str = "VID000001",
+                         processed_at_offset: float = 0.0) -> Path:
+    """Create a channel dir with one story, processed_at = time.time() + offset."""
+    import time as _time
+    channel_dir = storage_root / slug
+    channel_dir.mkdir(parents=True, exist_ok=True)
+    (channel_dir / "channel.json").write_text(
+        json.dumps({"channel_id": channel_id, "channel_name": channel_name})
+    )
+    meeting_dir = channel_dir / f"2026-01-15_{video_id}"
+    meeting_dir.mkdir(parents=True, exist_ok=True)
+    processed_at = now_utc_iso() if processed_at_offset == 0.0 else unix_to_iso8601(
+        _time.time() + processed_at_offset
+    )
+    (meeting_dir / "metadata.json").write_text(json.dumps({
+        "video_id": video_id,
+        "video_title": "Test Meeting",
+        "status": "processed",
+        "processed_at": processed_at,
+    }))
+    (meeting_dir / "01_Story.md").write_text(
+        f"# Story About {channel_name}\n*TESTVILLE — Jan 15, 2026*\n\nBody text.\n\n"
+        f"---\n**Segment Start:** 120s\n**Topics:** housing\n"
+    )
+    return channel_dir
+
+
+# -- _iter_all_users --
+
+def test_iter_all_users_yields_user_data(tmp_path, monkeypatch):
+    """_iter_all_users yields dicts for each valid user.json."""
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    users_root = tmp_path / "users"
+    _make_digest_user(users_root, "uid-abc", "alice@example.com", {})
+    _make_digest_user(users_root, "uid-def", "bob@example.com", {})
+
+    result = list(_tn_digest._iter_all_users())
+    emails = {u["email"] for u in result}
+    assert emails == {"alice@example.com", "bob@example.com"}
+    for u in result:
+        assert "_uid" in u
+        assert "_user_dir" in u
+
+
+def test_iter_all_users_skips_malformed(tmp_path, monkeypatch):
+    """_iter_all_users silently skips unreadable JSON files."""
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    users_root = tmp_path / "users"
+    _make_digest_user(users_root, "uid-good", "good@example.com", {})
+    bad_dir = users_root / "uid-bad"
+    bad_dir.mkdir()
+    (bad_dir / "user.json").write_text("not valid json")
+
+    result = list(_tn_digest._iter_all_users())
+    assert len(result) == 1
+    assert result[0]["email"] == "good@example.com"
+
+
+# -- _scan_stories_since --
+
+def test_scan_stories_since_returns_recent_stories(tmp_path, monkeypatch):
+    """Returns stories whose processed_at is newer than the cutoff."""
+    monkeypatch.setattr(_tn_digest, "STORAGE_ROOT", tmp_path)
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    _make_digest_channel(tmp_path, "alpha_city", "UC_ALPHA", "Alpha City Council")
+    user_data = {"channels": {"UC_ALPHA": []}}
+    cutoff = time.time() - 3600  # 1 hour ago — story should pass
+    stories = _tn_digest._scan_stories_since(user_data, "", cutoff)
+    assert len(stories) == 1
+    assert stories[0]["title"] == "Story About Alpha City Council"
+    assert stories[0]["channel_name"] == "Alpha City Council"
+    assert stories[0]["video_id"] == "VID000001"
+    assert stories[0]["start_seconds"] == 120
+
+
+def test_scan_stories_since_excludes_old_stories(tmp_path, monkeypatch):
+    """Stories older than the cutoff are filtered out."""
+    import time as _time
+    monkeypatch.setattr(_tn_digest, "STORAGE_ROOT", tmp_path)
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    _make_digest_channel(tmp_path, "alpha_city", "UC_ALPHA", "Alpha City Council",
+                         processed_at_offset=-7200.0)  # processed 2 hours ago
+    user_data = {"channels": {"UC_ALPHA": []}}
+    cutoff = _time.time() - 3600  # only within last hour
+    stories = _tn_digest._scan_stories_since(user_data, "", cutoff)
+    assert stories == []
+
+
+def test_scan_stories_since_excludes_unsubscribed_channels(tmp_path, monkeypatch):
+    """Stories from channels the user is not subscribed to are excluded."""
+    monkeypatch.setattr(_tn_digest, "STORAGE_ROOT", tmp_path)
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    _make_digest_channel(tmp_path, "alpha_city", "UC_ALPHA", "Alpha City Council")
+    _make_digest_channel(tmp_path, "beta_city", "UC_BETA", "Beta City Council",
+                         video_id="VID000002")
+    user_data = {"channels": {"UC_ALPHA": []}}  # not subscribed to BETA
+    cutoff = time.time() - 3600
+    stories = _tn_digest._scan_stories_since(user_data, "", cutoff)
+    channels = {s["channel_name"] for s in stories}
+    assert channels == {"Alpha City Council"}
+
+
+# -- _build_digest_html --
+
+def test_build_digest_html_contains_anchor_links():
+    """Each story headline links to the feed page anchor #s<video_id>-<start>."""
+    stories = [
+        {"title": "Council Approves Budget", "channel_name": "Alpha City",
+         "video_id": "AbCdEf12345", "start_seconds": 120},
+        {"title": "Zoning Vote Delayed", "channel_name": "Beta City",
+         "video_id": "XyZ9876543w", "start_seconds": 0},
+    ]
+    feed_url = "https://example.com/feed/mytoken.html"
+    html = _tn_digest._build_digest_html("Alice", "alice@example.com", stories, feed_url, "https://example.com")
+    assert "#sAbCdEf12345-120" in html
+    assert "#sXyZ9876543w-0" in html
+    assert "Council Approves Budget" in html
+    assert "Zoning Vote Delayed" in html
+    assert feed_url in html
+
+
+def test_build_digest_html_escapes_html_in_title():
+    """Story titles with HTML special characters are escaped."""
+    stories = [{"title": "<script>alert(1)</script>", "channel_name": "Chan",
+                "video_id": "VID1", "start_seconds": 0}]
+    html = _tn_digest._build_digest_html("Alice", "alice@example.com", stories,
+                                         "https://example.com/feed/tok.html",
+                                         "https://example.com")
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+# -- _send_daily_digests --
+
+def test_send_daily_digests_skips_when_no_api_key(tmp_path, monkeypatch):
+    """If resend_api_key is absent, _send_daily_digests returns immediately."""
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(_tn_digest, "STORAGE_ROOT", tmp_path)
+    sent = []
+    monkeypatch.setattr(_tn_digest, "_iter_all_users", lambda: iter([]))
+    # Should not raise and should not call any email API
+    _tn_digest._send_daily_digests({})  # no resend_api_key key
+    assert sent == []
+
+
+def test_send_daily_digests_skips_opted_out_users(tmp_path, monkeypatch):
+    """Users with digest_email_enabled=False are skipped."""
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(_tn_digest, "STORAGE_ROOT", tmp_path)
+    users_root = tmp_path / "users"
+    _make_digest_user(users_root, "uid-opt-out", "optout@example.com", {},
+                      digest_enabled=False)
+
+    send_calls = []
+
+    def fake_iter():
+        for u in _tn_digest._iter_all_users.__wrapped__() if hasattr(
+                _tn_digest._iter_all_users, "__wrapped__") else _tn_digest._iter_all_users():
+            yield u
+
+    # Patch resend import to detect any attempted send
+    import types
+    fake_resend = types.ModuleType("resend")
+    class FakeEmails:
+        @staticmethod
+        def send(params):
+            send_calls.append(params)
+    fake_resend.Emails = FakeEmails
+    monkeypatch.setitem(sys.modules, "resend", fake_resend)
+
+    _tn_digest._send_daily_digests({
+        "resend_api_key": "re_test_key",
+        "resend_from_email": "TubeNews <noreply@example.com>",
+        "base_url": "https://example.com",
+    })
+    assert send_calls == []
+
+
+def test_send_daily_digests_skips_when_no_base_url(tmp_path, monkeypatch, capsys):
+    """If base_url is not configured, no digest is sent."""
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(_tn_digest, "STORAGE_ROOT", tmp_path)
+    send_calls = []
+    import types
+    fake_resend = types.ModuleType("resend")
+    class FakeEmails:
+        @staticmethod
+        def send(params):
+            send_calls.append(params)
+    fake_resend.Emails = FakeEmails
+    monkeypatch.setitem(sys.modules, "resend", fake_resend)
+
+    _tn_digest._send_daily_digests({
+        "resend_api_key": "re_test_key",
+        # base_url intentionally omitted
+    })
+    assert send_calls == []
+
+
+def test_send_daily_digests_sends_to_opted_in_user(tmp_path, monkeypatch):
+    """An opted-in user with new stories receives a digest email."""
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(_tn_digest, "STORAGE_ROOT", tmp_path)
+    users_root = tmp_path / "users"
+    _make_digest_user(users_root, "uid-alice", "alice@example.com",
+                      {"UC_ALPHA": []}, token="alicetoken", digest_enabled=True)
+    _make_digest_channel(tmp_path, "alpha_city", "UC_ALPHA", "Alpha City Council")
+
+    send_calls = []
+    import types
+    fake_resend = types.ModuleType("resend")
+    class FakeEmails:
+        @staticmethod
+        def send(params):
+            send_calls.append(params)
+    fake_resend.Emails = FakeEmails
+    fake_resend.api_key = ""
+    monkeypatch.setitem(sys.modules, "resend", fake_resend)
+
+    _tn_digest._send_daily_digests({
+        "resend_api_key": "re_test_key",
+        "resend_from_email": "TubeNews <noreply@example.com>",
+        "base_url": "https://example.com",
+    })
+    assert len(send_calls) == 1
+    assert send_calls[0]["to"] == ["alice@example.com"]
+    assert "alicetoken" in send_calls[0]["html"]
+    # last_digest_sent should be written to user.json
+    uid_dir = users_root / "uid-alice"
+    saved = json.loads((uid_dir / "user.json").read_text())
+    assert "last_digest_sent" in saved
+
+
+def test_send_daily_digests_filters_stories_by_cutoff(tmp_path, monkeypatch):
+    """Stories older than last_digest_sent are not included in the email."""
+    import time as _time
+    monkeypatch.setattr(_tn_digest, "STATE_ROOT", tmp_path)
+    monkeypatch.setattr(_tn_digest, "STORAGE_ROOT", tmp_path)
+    users_root = tmp_path / "users"
+    # last_digest_sent = now → cutoff = now → no new stories
+    _make_digest_user(users_root, "uid-alice", "alice@example.com",
+                      {"UC_ALPHA": []}, token="alicetoken", digest_enabled=True,
+                      last_digest_sent=now_utc_iso())
+    _make_digest_channel(tmp_path, "alpha_city", "UC_ALPHA", "Alpha City Council",
+                         processed_at_offset=-3600.0)  # processed 1 hour ago
+
+    send_calls = []
+    import types
+    fake_resend = types.ModuleType("resend")
+    class FakeEmails:
+        @staticmethod
+        def send(params):
+            send_calls.append(params)
+    fake_resend.Emails = FakeEmails
+    fake_resend.api_key = ""
+    monkeypatch.setitem(sys.modules, "resend", fake_resend)
+
+    _tn_digest._send_daily_digests({
+        "resend_api_key": "re_test_key",
+        "resend_from_email": "TubeNews <noreply@example.com>",
+        "base_url": "https://example.com",
+    })
+    assert send_calls == []  # no new stories → no email sent

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -3121,3 +3121,39 @@ def test_post_comment_path_traversal_rejected(logged_in_client, archive, monkeyp
         "body":         "Hello",
     })
     assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# digest_email_enabled preference — saved via action==prefs
+# ---------------------------------------------------------------------------
+
+def test_account_prefs_saves_digest_email_enabled(logged_in_client, archive):
+    """Submitting the prefs form with digest_email_enabled checked stores True."""
+    r = logged_in_client.post("/account", data={
+        "action": "prefs",
+        "font_size": "normal",
+        "digest_email_enabled": "on",
+    }, follow_redirects=True)
+    assert r.status_code == 200
+
+    users_root = archive / "state" / "users"
+    user_jsons = list(users_root.glob("*/user.json"))
+    assert user_jsons
+    data = json.loads(user_jsons[0].read_text())
+    assert data.get("preferences", {}).get("digest_email_enabled") is True
+
+
+def test_account_prefs_digest_unchecked_saves_false(logged_in_client, archive):
+    """Submitting the prefs form without digest_email_enabled stores False."""
+    r = logged_in_client.post("/account", data={
+        "action": "prefs",
+        "font_size": "normal",
+        # digest_email_enabled intentionally omitted (unchecked checkbox)
+    }, follow_redirects=True)
+    assert r.status_code == 200
+
+    users_root = archive / "state" / "users"
+    user_jsons = list(users_root.glob("*/user.json"))
+    assert user_jsons
+    data = json.loads(user_jsons[0].read_text())
+    assert data.get("preferences", {}).get("digest_email_enabled") is False

--- a/web/app.py
+++ b/web/app.py
@@ -1250,7 +1250,9 @@ def account():
             if timezone and timezone not in pytz.all_timezones:
                 flash("Invalid timezone.", "error")
                 return redirect(url_for("account"))
-            current_user._data["preferences"] = {"font_size": font_size, "dark_mode": dark_mode}
+            digest_email_enabled = "digest_email_enabled" in request.form
+            current_user._data["preferences"] = {"font_size": font_size, "dark_mode": dark_mode,
+                                                  "digest_email_enabled": digest_email_enabled}
             if timezone:
                 current_user._data["preferences"]["timezone"] = timezone
             current_user._save()

--- a/web/templates/account.html
+++ b/web/templates/account.html
@@ -199,6 +199,14 @@
         </select>
       </div>
 
+      <div class="form-row" style="margin-top:1rem;">
+        <label class="checkbox-label">
+          <input type="checkbox" name="digest_email_enabled"
+                 {% if prefs.get('digest_email_enabled') %}checked{% endif %}>
+          Send me a daily email digest of new stories
+        </label>
+      </div>
+
       <button type="submit" class="btn-save">Save display preferences</button>
     </form>
   </section>


### PR DESCRIPTION
Users can opt in to a morning digest email from the account settings page (Display section). The digest lists new story headlines since the last email, each linking directly to the story anchor on their personal feed page (#s<video_id>-<start_seconds>).

- Add `resend` to requirements.txt
- New config keys: resend_api_key, resend_from_email, email_digest_send_hour
- _iter_all_users() generator reads state/users/*/user.json without Flask
- _scan_stories_since() filters subscribed-channel stories by processed_at
- _build_digest_html() renders HTML email with anchor deep-links
- _send_daily_digests() sends via Resend, writes last_digest_sent atomically
- Wired into _wsb_processor_thread with time-of-day + 24h guard
- digest_email_enabled preference saved by account prefs route
- 14 new tests covering all digest helpers and the opt-in preference save
- CLAUDE.md updated with config keys, function reference, user.json schema

https://claude.ai/code/session_01WxK99Ubahhdm2qscEZdGjy