### PR TITLE
Fix duplicate backoff notices and clarify cached transcript logging

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -1727,8 +1727,8 @@ def process_video(
 
     # --- Load or fetch transcript ---
     if existing_dir and (existing_dir / "transcript.txt").exists():
-        # Re-use cached transcript; only the AI step needs to re-run.
-        logger.info(f"{log_prefix} TubeNews: Found cached transcript, re-running AI")
+        # Re-use cached transcript; only the AI step needs to re-run (if not disabled).
+        logger.info(f"{log_prefix} TubeNews: Found cached transcript")
         transcript_text = (existing_dir / "transcript.txt").read_text(encoding="utf-8")
         meeting_dir = existing_dir
     else:
@@ -3322,6 +3322,9 @@ def _wsb_processor_thread(config: dict) -> None:
                         f"WebSub processor: Gemini {msg} — backing off "
                         f"AI calls for {backoff_secs // 60}m {backoff_secs % 60}s"
                     )
+                    # Stop processing more channels once we hit an error.
+                    # Remaining channels' entries stay in the queue for next cycle.
+                    break
 
                 gemini_count += len(entries)
 


### PR DESCRIPTION
**Issue 1: Multiple "5m backoff" notices**
When multiple channels hit 503 in the same cycle, each one triggered the backoff message. Now we break out of the channel loop immediately after the first 503, preventing redundant logging and avoiding hammering Gemini when it's already down.

**Issue 2: Misleading "Found cached transcript, re-running AI" message** The message claimed AI would re-run, but if AI was disabled due to backoff, it would just be skipped. Changed to neutral "Found cached transcript" and let the actual Gemini "Generating stories" log show whether AI actually runs.

**Result:**
- Single backoff notice per cycle (not one per channel)
- Clearer logs that don't promise AI will run if it's going to be skipped
- Processor stops wasting cycles on more channels once service is confirmed down

https://claude.ai/code/session_012KV4itvLRGQnNGC8Lmgbyw