### PR TITLE
Fix: email digest template not interpolating variables

### DIFF
--- a/TubeNews.py
+++ b/TubeNews.py
@@ -3728,11 +3728,12 @@ def _build_digest_html(name: str, email: str, stories: list[dict], feed_url: str
             f' <a href="{account_url}" style="color:#888">Manage preferences</a>.'
         )
     footer += "</p>"
-    return """<!DOCTYPE html>
+    name_escaped = _html.escape(name)
+    return f"""<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"></head>
 <body style="font-family:Georgia,serif;max-width:600px;margin:0 auto;padding:1.5em;color:#111">
-  <p>Hi {_html.escape(name)}, here are your {story_count} new {story_word} from TubeNews:</p>
+  <p>Hi {name_escaped}, here are your {story_count} new {story_word} from TubeNews:</p>
   <ul style="padding-left:1.2em;line-height:1.7">
 {items_html}
   </ul>

--- a/tests/test_tubenews.py
+++ b/tests/test_tubenews.py
@@ -3643,6 +3643,32 @@ def test_build_digest_html_escapes_html_in_title():
     assert "&lt;script&gt;" in html
 
 
+def test_build_digest_html_interpolates_name_and_counts():
+    """Regression: template must be an f-string so variables are substituted."""
+    stories = [
+        {"title": "Story One", "channel_name": "Channel", "video_id": "VID1", "start_seconds": 0},
+        {"title": "Story Two", "channel_name": "Channel", "video_id": "VID2", "start_seconds": 10},
+    ]
+    html = _tn_digest._build_digest_html("Bob", "bob@example.com", stories,
+                                         "https://example.com/feed/tok.html",
+                                         "https://example.com")
+    assert "Hi Bob" in html, "name must be interpolated (not literal {name})"
+    assert "2 new stories" in html, "story count must be interpolated"
+    assert "{story_count}" not in html
+    assert "{_html.escape(name)}" not in html
+    assert "{items_html}" not in html
+
+
+def test_build_digest_html_escapes_name():
+    """Names with HTML special characters are escaped to prevent XSS."""
+    stories = [{"title": "Story", "channel_name": "Chan", "video_id": "VID1", "start_seconds": 0}]
+    html = _tn_digest._build_digest_html("<b>Eve</b>", "eve@example.com", stories,
+                                         "https://example.com/feed/tok.html",
+                                         "https://example.com")
+    assert "<b>Eve</b>" not in html
+    assert "&lt;b&gt;Eve&lt;/b&gt;" in html
+
+
 # -- _send_daily_digests --
 
 def test_send_daily_digests_skips_when_no_api_key(tmp_path, monkeypatch):


### PR DESCRIPTION
The _build_digest_html return string was missing the f prefix, causing recipients to see raw {story_count}, {_html.escape(name)}, etc. in their emails. Also extract name_escaped before the f-string to keep html.escape() out of the interpolation expression.

Adds three regression tests: name interpolation, story count, and name HTML-escaping.