### PR TITLE
Fix: admin user preferences missing email and podcast options

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1898,7 +1898,11 @@ def admin_user_prefs(uid: str):
     if timezone and timezone not in pytz.all_timezones:
         flash("Invalid timezone.", "error")
         return redirect(url_for("admin_user", uid=uid))
-    user._data["preferences"] = {"font_size": font_size, "dark_mode": dark_mode}
+    digest_email_enabled = "digest_email_enabled" in request.form
+    podcast_enabled = "podcast_enabled" in request.form
+    user._data["preferences"] = {"font_size": font_size, "dark_mode": dark_mode,
+                                 "digest_email_enabled": digest_email_enabled,
+                                 "podcast_enabled": podcast_enabled}
     if timezone:
         user._data["preferences"]["timezone"] = timezone
     user._save()

--- a/web/templates/admin_user.html
+++ b/web/templates/admin_user.html
@@ -152,6 +152,16 @@
                {% if u._data.get('preferences', {}).get('dark_mode') %}checked{% endif %}>
         Dark mode
       </label>
+      <label class="checkbox-label">
+        <input type="checkbox" name="digest_email_enabled"
+               {% if u._data.get('preferences', {}).get('digest_email_enabled') %}checked{% endif %}>
+        Receive daily email digest
+      </label>
+      <label class="checkbox-label">
+        <input type="checkbox" name="podcast_enabled"
+               {% if u._data.get('preferences', {}).get('podcast_enabled') %}checked{% endif %}>
+        Generate daily podcast episodes
+      </label>
       <div class="form-row" style="margin-top:1rem;">
         <label for="timezone">Timezone</label>
         <select name="timezone" id="timezone" style="max-width: 300px;">


### PR DESCRIPTION
The admin_user_prefs endpoint was only saving font_size, dark_mode, and timezone but was missing digest_email_enabled and podcast_enabled. Also added the corresponding checkboxes to the admin_user.html template so admins can actually set these preferences.

This brings the admin user edit page into sync with the user's own /account page preferences.