### PR TITLE
Add relative date display for story dates

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -598,6 +598,28 @@ def format_datetime(ts: int | str | None) -> str:
         return datetime.fromtimestamp(ts_float, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
 
+@app.template_filter("relative_date")
+def relative_date(date_str: str | None) -> str:
+    """Convert YYYY-MM-DD date to 'Today', 'Yesterday', or the date string."""
+    if not date_str:
+        return "—"
+    try:
+        tz_name = _get_user_timezone(current_user)
+        tz = pytz.timezone(tz_name)
+        today = datetime.now(tz=tz).date()
+        date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
+
+        if date_obj == today:
+            return "Today"
+        elif date_obj == today - __import__('datetime').timedelta(days=1):
+            return "Yesterday"
+        else:
+            return date_str
+    except Exception:
+        return date_str
+
+
+
 # Canonical implementation lives in tubenews_utils.sanitize_focus (imported
 # via TubeNews).  Alias preserves private naming used throughout this file and
 # in existing test imports (from web.app import _sanitize_focus).

--- a/web/templates/feed.html
+++ b/web/templates/feed.html
@@ -148,8 +148,8 @@
     {% for story in stories %}
     <article class="story" id="s{{ story.video_id }}-{{ story.start_seconds }}" data-channel-id="{{ story.channel_id }}">
       <h2>{% if query is defined and query %}{{ story.title | highlight(query) | safe }}{% else %}{{ story.title }}{% endif %}</h2>
-      {% if story.video_date %}<p class="story-dateline"><em>{{ story.video_date }}</em></p>{% endif %}
-      {% if story.published %}<p class="story-published"><em>Published {{ story.published }}</em></p>{% endif %}
+      {% if story.video_date %}<p class="story-dateline"><em>{{ story.video_date | relative_date }}</em></p>{% endif %}
+      {% if story.published %}<p class="story-published"><em>Published {{ story.published | relative_date }}</em></p>{% endif %}
       <p class="story-source">
         {{ story.channel_name }}{% if story.video_title %} &mdash; {{ story.video_title }}{% endif %}
       </p>


### PR DESCRIPTION
New Jinja2 filter 'relative_date' converts YYYY-MM-DD dates to:
- 'Today' for today
- 'Yesterday' for yesterday
- The original date string for older dates

Respects user's timezone preference. Applied to both:
- story.video_date (recording/published date)
- story.published (processing date)

Makes the feed more natural to read - you see 'Today' and 'Yesterday' instead of specific dates for recent content.