### PR TITLE
Style story title links to match UI feel

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1002,6 +1002,15 @@ main:has(.feed-layout) {
   margin-bottom: 0.25rem;
 }
 
+.story h2 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.story h2 a:hover {
+  text-decoration: underline;
+}
+
 .story-dateline {
   font-style: italic;
   color: var(--muted);


### PR DESCRIPTION
Story titles now inherit text color (no blue) and remove underline by default. Underline appears on hover to indicate clickability, keeping the design subtle and consistent with the rest of the interface.

https://claude.ai/code/session_012KV4itvLRGQnNGC8Lmgbyw