### PR TITLE
Fix relative_date filter to preserve time when replacing date

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -681,11 +681,11 @@ def relative_date(date_str: str | None) -> str:
                 return date_str
 
         if date_obj == today:
-            # Replace the date part with "Today"
-            return re.sub(r'\w+\s+\d+,\s+\d{4}', 'Today', date_str) if 'published' in date_str.lower() else "Today"
+            # Replace the date part with "Today" (preserves time if present)
+            return re.sub(r'\w+\s+\d+,\s+\d{4}', 'Today', date_str)
         elif date_obj == today - timedelta(days=1):
-            # Replace the date part with "Yesterday"
-            return re.sub(r'\w+\s+\d+,\s+\d{4}', 'Yesterday', date_str) if 'published' in date_str.lower() else "Yesterday"
+            # Replace the date part with "Yesterday" (preserves time if present)
+            return re.sub(r'\w+\s+\d+,\s+\d{4}', 'Yesterday', date_str)
         else:
             return date_str
     except Exception as exc:


### PR DESCRIPTION
Removed the check for 'published' in the string, which was causing the filter to return just 'Today' instead of 'Today at 3:15 PM PDT'. The 'Published' word is added by the template, not included in the story.published value.

Now the regex properly replaces only the 'Month Day, Year' part and preserves any time information, timezone, and other text.

Before: 'April 21, 2026 at 09:47 AM PDT' → 'Today'
After:  'April 21, 2026 at 09:47 AM PDT' → 'Today at 09:47 AM PDT'

https://claude.ai/code/session_012KV4itvLRGQnNGC8Lmgbyw