### PR TITLE
Fix voting not working - add credentials to fetch requests

### DIFF
--- a/web/templates/article.html
+++ b/web/templates/article.html
@@ -66,7 +66,9 @@
     var basename = section.dataset.basename;
     if (!channelSlug || !meetingId || !basename) return;
 
-    fetch('/votes/' + channelSlug + '/' + meetingId + '/' + basename)
+    fetch('/votes/' + channelSlug + '/' + meetingId + '/' + basename, {
+      credentials: 'include'
+    })
       .then(function (r) { return r.json(); })
       .then(function (data) {
         section.querySelector('.vote-up .vote-count').textContent = data.up;
@@ -98,7 +100,8 @@
         e.preventDefault();
         var direction = btn.classList.contains('vote-up') ? 'up' : 'down';
         fetch('/vote/' + channelSlug + '/' + meetingId + '/' + basename + '/' + direction, {
-          method: 'POST'
+          method: 'POST',
+          credentials: 'include'
         })
           .then(function (r) { return r.json(); })
           .then(function (data) {

--- a/web/templates/feed.html
+++ b/web/templates/feed.html
@@ -943,7 +943,9 @@
       var basename = section.dataset.basename;
       if (!channelSlug || !meetingId || !basename) return;
 
-      fetch('/votes/' + channelSlug + '/' + meetingId + '/' + basename)
+      fetch('/votes/' + channelSlug + '/' + meetingId + '/' + basename, {
+        credentials: 'include'
+      })
         .then(function (r) { return r.json(); })
         .then(function (data) {
           section.querySelector('.vote-up .vote-count').textContent = data.up;
@@ -975,7 +977,8 @@
           e.preventDefault();
           var direction = btn.classList.contains('vote-up') ? 'up' : 'down';
           fetch('/vote/' + channelSlug + '/' + meetingId + '/' + basename + '/' + direction, {
-            method: 'POST'
+            method: 'POST',
+            credentials: 'include'
           })
             .then(function (r) { return r.json(); })
             .then(function (data) {


### PR DESCRIPTION
The vote system wasn't working because fetch requests weren't including credentials. Without credentials: 'include', browser cookies (including the session cookie) weren't being sent with the requests, so:

1. Anonymous users: Session cookie wasn't being created/sent, so each vote appeared to be from a different user
2. Logged-in users: Session cookie wasn't sent, breaking session identification

Added credentials: 'include' to all fetch() calls in the voting system:
- GET /votes/{channel}/{meeting}/{story} - load vote counts
- POST /vote/{channel}/{meeting}/{story}/{direction} - cast vote

This ensures:
- Session cookies are sent with requests
- Anonymous users get consistent session IDs
- Logged-in users are properly identified
- UI updates immediately when votes are cast

https://claude.ai/code/session_012KV4itvLRGQnNGC8Lmgbyw