### PR TITLE
Fix voting system JSON parse errors by checking response status

### DIFF
--- a/web/templates/article.html
+++ b/web/templates/article.html
@@ -69,7 +69,13 @@
     fetch('/votes/' + channelSlug + '/' + meetingId + '/' + basename, {
       credentials: 'include'
     })
-      .then(function (r) { return r.json(); })
+      .then(function (r) {
+        if (!r.ok) {
+          console.error('Vote fetch failed:', r.status, r.statusText);
+          return Promise.reject('HTTP ' + r.status);
+        }
+        return r.json();
+      })
       .then(function (data) {
         section.querySelector('.vote-up .vote-count').textContent = data.up;
         section.querySelector('.vote-down .vote-count').textContent = data.down;
@@ -103,7 +109,13 @@
           method: 'POST',
           credentials: 'include'
         })
-          .then(function (r) { return r.json(); })
+          .then(function (r) {
+            if (!r.ok) {
+              console.error('Vote POST failed:', r.status, r.statusText);
+              return Promise.reject('HTTP ' + r.status);
+            }
+            return r.json();
+          })
           .then(function (data) {
             if (data.ok) {
               // Update counts

--- a/web/templates/feed.html
+++ b/web/templates/feed.html
@@ -947,11 +947,17 @@
         return;
       }
 
-      fetch('/votes/' + channelSlug + '/' + meetingId + '/' + basename, {
+      var url = '/votes/' + channelSlug + '/' + meetingId + '/' + basename;
+      console.log('Fetching votes from:', url);
+      fetch(url, {
         credentials: 'include'
       })
         .then(function (r) {
           console.log('Vote load response:', r.status);
+          if (!r.ok) {
+            console.error('Vote fetch failed:', r.status, r.statusText);
+            return Promise.reject('HTTP ' + r.status);
+          }
           return r.json();
         })
         .then(function (data) {
@@ -995,6 +1001,10 @@
           })
             .then(function (r) {
               console.log('Vote POST response:', r.status);
+              if (!r.ok) {
+                console.error('Vote POST failed:', r.status, r.statusText);
+                return Promise.reject('HTTP ' + r.status);
+              }
               return r.json();
             })
             .then(function (data) {


### PR DESCRIPTION
The voting fetch handlers were calling r.json() even on error responses (400, 404), which caused "JSON.parse: unexpected character" errors because Flask's abort() returns HTML error pages, not JSON.

Add response status checks (.ok) before calling r.json() in both fetch chains for loading and posting votes. Also improve logging to show the full URL being requested for better debugging.

- Check r.ok before calling r.json() in GET /votes and POST /vote handlers
- Log full vote fetch URL for debugging
- Reject promise on non-OK responses to trigger catch handler

https://claude.ai/code/session_012KV4itvLRGQnNGC8Lmgbyw