### PR TITLE
Fix transcript search regex lastIndex bug

### DIFF
--- a/web/templates/transcript.html
+++ b/web/templates/transcript.html
@@ -222,6 +222,7 @@
 
       var text = textCell.textContent;
       var match;
+      regex.lastIndex = 0;
       while ((match = regex.exec(text)) !== null) {
         matches.push({
           row: row,


### PR DESCRIPTION
When using regex.exec() with the global flag in a loop across multiple rows, the regex maintains a lastIndex property that causes it to skip or miss matches in subsequent rows.

Reset regex.lastIndex = 0 for each row to ensure all matches are found. Fixes issue where searches like 'alc' would fail to match 'alcoholic'.

https://claude.ai/code/session_012KV4itvLRGQnNGC8Lmgbyw