### PR TITLE
Fix subscribe endpoint for Popular view Join buttons

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -2046,6 +2046,31 @@ def account_mark_unstarred():
     return jsonify({"ok": True})
 
 
+@app.route("/account/subscribe", methods=["POST"])
+@csrf.exempt
+@login_required
+def subscribe_channel():
+    """Subscribe user to a channel (AJAX endpoint for Popular view)."""
+    channel_id = request.form.get("channel_id", "").strip()
+    if not channel_id:
+        return jsonify({"ok": False, "error": "missing channel_id"}), 400
+
+    # Check if channel exists
+    channels = _load_channels()
+    channel = next((ch for ch in channels if ch.get("channel_id") == channel_id), None)
+    if not channel:
+        return jsonify({"ok": False, "error": "channel not found"}), 404
+
+    # Check if already subscribed
+    if channel_id in current_user.channel_ids:
+        return jsonify({"ok": True})  # Already subscribed, treat as success
+
+    # Add to subscriptions
+    current_user._data.setdefault("channels", {})[channel_id] = {"focus": ""}
+    current_user._save()
+    return jsonify({"ok": True})
+
+
 # ---------------------------------------------------------------------------
 # Comment routes
 # ---------------------------------------------------------------------------

--- a/web/templates/feed.html
+++ b/web/templates/feed.html
@@ -1089,7 +1089,7 @@
       var originalText = btn.textContent;
       btn.textContent = 'Joining...';
 
-      fetch('{{ url_for("account_subscribe") }}', {
+      fetch('{{ url_for("subscribe_channel") }}', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: 'csrf_token=' + encodeURIComponent({{ csrf_token() | tojson }}) + '&channel_id=' + encodeURIComponent(channelId),


### PR DESCRIPTION
Create /account/subscribe POST endpoint for AJAX subscription from Popular view. Endpoint validates channel exists and prevents duplicate subscriptions.

Update template to use correct subscribe_channel endpoint.

https://claude.ai/code/session_012KV4itvLRGQnNGC8Lmgbyw