### PR TITLE
Fix Lobotomy API integration to match actual API spec

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -3021,18 +3021,24 @@ def api_lobotomy_push():
         return jsonify({"error": "Lobotomy not configured for this account"}), 400
 
     try:
+        # Build payload for Lobotomy API
+        payload = {"source": "TubeNews"}
+        if data.get("title"):
+            payload["title"] = data["title"]
+        if data.get("content"):
+            payload["content"] = data["content"]
+        if data.get("url"):
+            payload["url"] = data["url"]
+        if data.get("tags"):
+            payload["tags"] = data["tags"]
+
         resp = requests.post(
             f"{lobotomy_url}/api/push",
             headers={
                 "Authorization": f"Bearer {lobotomy_key}",
                 "Content-Type": "application/json",
             },
-            json={
-                "title": data.get("title"),
-                "content": data.get("content"),
-                "source_url": data.get("source_url"),
-                "tags": data.get("tags", []),
-            },
+            json=payload,
             timeout=10,
         )
         resp.raise_for_status()

--- a/web/templates/feed.html
+++ b/web/templates/feed.html
@@ -460,7 +460,7 @@
       var payload = {
         title: title,
         content: body,
-        source_url: youtubeUrl,
+        url: youtubeUrl,
         tags: [document.querySelector('article').dataset.channelId || ''] // channel as tag
       };
 


### PR DESCRIPTION
- Update backend endpoint to build correct Lobotomy API payload with proper field names (url instead of source_url)
- Add 'source' field set to 'TubeNews' for application identification
- Update frontend to send 'url' field instead of 'source_url'
- Only include non-empty fields in the payload

Fixes HTTP 400 errors caused by incorrect field names not matching Lobotomy API specification.

https://claude.ai/code/session_01MyhoRmx8CXXPoXiMyMKpMA